### PR TITLE
Update nanoDFT to use jsonargparse

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ tqdm
 pytest
 natsort
 rdkit
+jsonargparse[all]
 
 # silence warnings about setuptools + numpy
 setuptools < 60.0


### PR DESCRIPTION
Usage
```
$ python nanoDFT.py --help
usage: nanoDFT.py [-h] [--config CONFIG] [--print_config[=flags]] [--its ITS] [--mol_str MOL_STR] [--ipumult {true,false}] [--float32 {true,false}] [--basis BASIS]
                  [--xc XC] [--backend BACKEND] [--level LEVEL] [--gdb GDB] [--multv MULTV] [--intv INTV] [--skipDIIS {true,false}] [--threads THREADS]
                  [--threads_int THREADS_INT]

nanoDFT

optional arguments:
  -h, --help            Show this help message and exit.
  --config CONFIG       Path to a configuration file.
  --print_config[=flags]
                        Print the configuration after applying all other arguments and exit. The optional flags customizes the output and are one or more keywords
                        separated by comma. The supported flags are: comments, skip_default, skip_null.
  --its ITS             Number of Kohn-Sham iterations. (type: int, default: 20)
  --mol_str MOL_STR     Molecule string, e.g., "H 0 0 0; H 0 0 1; O 1 0 0; " (type: str, default: )
  --ipumult {true,false}
                        For IPU. Use (N, N, N, N) ERI computed with PySCF on CPU. (and not our Rys Quadrature implementation). (type: bool, default: False)
  --float32 {true,false}
                        Whether to use float32 (default is float64). (type: bool, default: False)
  --basis BASIS         Which Gaussian basis set to use. (type: str, default: STO-3G)
  --xc XC               Exchange-correlation functional. Only support B3LYP (type: str, default: b3lyp)
  --backend BACKEND     Accelerator backend to use: "-backend cpu" or "-backend ipu". (type: str, default: cpu)
  --level LEVEL         Level of grids for XC numerical integration. (type: int, default: 2)
  --gdb GDB             Which version of GDP to load {10, 11, 13, 17}. (type: int, default: -1)
  --multv MULTV         Which version of our einsum algorithm to use;comptues ERI@flat(v). Different versions trades-off for memory vs sequentiality (type: int,
                        default: 2)
  --intv INTV           Which version to use of our integral algorithm. (type: int, default: 1)
  --skipDIIS {true,false}
                        Whether to skip DIIS; useful for benchmarking. (type: bool, default: False)
  --threads THREADS     For -backend ipu. Number of threads for einsum(ERI, dm) with custom C++ (trades-off speed vs memory). (type: int, default: 1)
  --threads_int THREADS_INT
                        For -backend ipu. Number of threads for computing ERI with custom C++ (trades off speed vs memory). (type: int, default: 1)
```