### PR TITLE
use requirements file in nanoDFT Demo Notebook

### DIFF
--- a/notebooks/nanoDFT-demo.ipynb
+++ b/notebooks/nanoDFT-demo.ipynb
@@ -27,9 +27,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -q jax==0.3.16+ipu jaxlib==0.3.15+ipu.sdk320 -f https://graphcore-research.github.io/jax-experimental/wheels.html\n",
-    "%pip install -q git+https://github.com/graphcore-research/tessellate-ipu.git@main\n",
-    "%pip install -q py3Dmol"
+    "%pip install -q -r ../requirements_ipu.txt"
    ]
   },
   {

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ jsonargparse[all]
 
 mogli
 imageio[ffmpeg]
+py3Dmol
 
 # silence warnings about setuptools + numpy
 setuptools < 60.0


### PR DESCRIPTION
This fixes an environment problem when running the nanoDFT notebook by following the run on gradient link.