### PR TITLE
Add simple QM1B dataset readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 
 [**Installation guide**](#installation)
 | [**Example DFT Computations**](#example-dft-computations)
-| [**Generating new datasets**](#generating-new-datasets)
+| [**Generating data**](#generating-new-datasets)
 | [**Training SchNet**](#training-schnet-on-qm1b)
+| [**QM1B dataset**](qm1b/README.md)
 
 [![Run on Gradient](https://assets.paperspace.io/img/gradient-badge.svg)](https://ipu.dev/ipobmC)
 
@@ -34,7 +35,7 @@ pip install -r requirements_ipu.txt
 ```
 This will configure Graphcore research experimental JAX support in your python environment.
 
-We recommend upgrading `pip` to the latest stable release when using the IPU 
+We recommend upgrading `pip` to the latest stable release when using the IPU
 requirements. This may be an optional step depending on the overall configuration of
 your python environment.
 
@@ -71,9 +72,9 @@ python density_functional_theory.py -generate -save -fname dataset_name -level 0
 You can speed up the generation by using IPUs. Please try the [DFT dataset generation notebook](https://ipu.dev/YX0jlK) [![Run on Gradient](https://assets.paperspace.io/img/gradient-badge.svg)](https://ipu.dev/YX0jlK)
 
 
-## Training SchNet on QM1B
+## Training SchNet on [QM1B](qm1b/README.md)
 
-We used PySCF on IPU to generate the QM1B dataset with one billion training examples (to be released soon).
+We used PySCF on IPU to generate the [QM1B dataset](qm1b/README.md) with one billion training examples (to be released soon).
 See [Training SchNet on QM1B](./schnet_9m/README.md) for an example implementation of a neural network trained on this dataset.
 
 ## License

--- a/qm1b/README.md
+++ b/qm1b/README.md
@@ -1,0 +1,29 @@
+# QM1B dataset (to be released soon)
+
+QM1B is a low-resolution DFT dataset generated using [PySCF IPU](https://github.com/graphcore-research/pyscf-ipu). It is composed of one billion training examples containing 9-11 heavy atoms. It was created by taking 1.09M SMILES strings from the [GDB-11 database](https://zenodo.org/record/5172018) and computing molecular properties (e.g. HOMO-LUMO gap) for a set of up to 1000 conformers per molecule.
+
+## Dataset schema
+
+QM1B dataset is stored in the [open-source columnar Apache Parquet format](https://parquet.apache.org/), with the following schema:
+* `smile`: The SMILES string taken from GDB11. There are up to 1000 rows (i.e. conformers) with the same SMILES
+string.
+* `atoms`: String representing the atom symbols of the molecule, e.g. ”COOH”.
+* `z`: Integer representation of `atoms` used by SchNet (the atomic numbers).
+* `energy`: energy of the molecule computed by PySCF IPU (unit eV).
+* `homo`: The energy of the Highest Occupied Molecular Orbital (HOMO) (unit eV).
+* `lumo`: The energy of the Lowest occupied Molecular Orbital (LUMO) (unit eV).
+* `N`: The number of atomic orbitals for the specific DFT computation (depends on the basis set STO3G).
+* `std`: The standard deviation of the energy of the last five iterations of running PySCFIPU, used as
+convergence criteria std < 0.01 (unit eV).
+* `y`: The HOMO-LUMO Gap (unit eV).
+* `pos`: The atom positions (unit Bohr).
+
+## Dataset exploration
+
+Dataset exploration can easily done using Pandas library. For instance, to load the validation set:
+```python
+import pandas as pd
+
+# 20m entries in the validation set.
+print(pd.read_parquet("qm1b_val.parquet"))
+```

--- a/qm1b/README.md
+++ b/qm1b/README.md
@@ -25,5 +25,5 @@ Dataset exploration can easily done using Pandas library. For instance, to load 
 import pandas as pd
 
 # 20m entries in the validation set.
-print(pd.read_parquet("qm1b_val.parquet"))
+print(pd.read_parquet("qm1b_val.parquet").head())
 ```


### PR DESCRIPTION
QM1B is a low-resolution DFT dataset generated using [PySCF IPU](https://github.com/graphcore-research/pyscf-ipu). It is composed of one billion training examples containing 9-11 heavy atoms. It was created by taking 1.09M SMILES strings from the [GDB-11 database](https://zenodo.org/record/5172018) and computing molecular properties (e.g. HOMO-LUMO gap) for a set of up to 1000 conformers per molecule.