### PR TITLE
Don't set exe path at top level

### DIFF
--- a/nanoDFT/nanoDFT.py
+++ b/nanoDFT/nanoDFT.py
@@ -6,8 +6,7 @@ import pyscf
 from jsonargparse import CLI, Namespace
 import sys
 sys.path.append("../")
-import os 
-os.environ['TF_POPLAR_FLAGS'] = """--executable_cache_path=/tmp/pyscf-ipu-cache/"""
+
 from exchange_correlation.b3lyp import b3lyp
 from electron_repulsion.direct import prepare_electron_repulsion_integrals, electron_repulsion_integrals, ipu_einsum
 from functools import partial


### PR DESCRIPTION
The user may have set it themselves, and another file importing this file may have set it.