### PR TITLE
Improve packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ We recommend upgrading `pip` to the latest stable release when using the IPU
 requirements. This may be an optional step depending on the overall configuration of
 your python environment.
 
+And finally, make our sub-packages available:
+```bash
+pip install -e .
+```
+
 ## Example DFT Computations
 The following commands may be useful to check the installation. Each command runs a test-case which compares PySCF against our DFT computation using different options.
 ```

--- a/exchange_correlation/b3lyp.py
+++ b/exchange_correlation/b3lyp.py
@@ -2,17 +2,10 @@
 import jax.numpy as jnp
 import jax
 
-try:
-    # When do we expect these to fail?
-    from exchange_correlation.lda import __lda
-    from exchange_correlation.lyp import __lyp
-    from exchange_correlation.b88 import __b88
-    from exchange_correlation.vwn import __vwn
-except:
-    from lda import __lda
-    from lyp import __lyp
-    from b88 import __b88
-    from vwn import __vwn
+from exchange_correlation.lda import __lda
+from exchange_correlation.lyp import __lyp
+from exchange_correlation.b88 import __b88
+from exchange_correlation.vwn import __vwn
 
 CLIP_RHO_MIN  = 1e-9
 CLIP_RHO_MAX  = 1e12

--- a/exchange_correlation/b3lyp.py
+++ b/exchange_correlation/b3lyp.py
@@ -2,11 +2,8 @@
 import jax.numpy as jnp
 import jax
 
-import sys
-import pathlib
-sys.path.append( str(pathlib.Path().resolve()) + "/" )
-
 try:
+    # When do we expect these to fail?
     from exchange_correlation.lda import __lda
     from exchange_correlation.lyp import __lyp
     from exchange_correlation.b88 import __b88

--- a/nanoDFT/__init__.py
+++ b/nanoDFT/__init__.py
@@ -1,0 +1,1 @@
+from .nanoDFT import *

--- a/nanoDFT/experimental_pmap_nanoDFT.py
+++ b/nanoDFT/experimental_pmap_nanoDFT.py
@@ -2,14 +2,8 @@
 import jax
 import jax.numpy as jnp
 import numpy as np
-import os
-os.environ['OMP_NUM_THREADS'] = "16"
 import pyscf
 from jsonargparse import CLI, Namespace
-import sys
-sys.path.append("../")
-import os 
-os.environ['TF_POPLAR_FLAGS'] = """--executable_cache_path=/tmp/pyscf-ipu-cache/"""
 from exchange_correlation.b3lyp import b3lyp
 from electron_repulsion.direct import prepare_electron_repulsion_integrals, electron_repulsion_integrals, ipu_einsum
 from functools import partial

--- a/nanoDFT/nanoDFT.py
+++ b/nanoDFT/nanoDFT.py
@@ -6,8 +6,7 @@ import pyscf
 from jsonargparse import CLI, Namespace
 import sys
 sys.path.append("../")
-import os 
-os.environ['TF_POPLAR_FLAGS'] = """--executable_cache_path=/tmp/pyscf-ipu-cache/"""
+
 from exchange_correlation.b3lyp import b3lyp
 from electron_repulsion.direct import prepare_electron_repulsion_integrals, electron_repulsion_integrals, ipu_einsum
 from functools import partial

--- a/nanoDFT/nanoDFT.py
+++ b/nanoDFT/nanoDFT.py
@@ -4,8 +4,6 @@ import jax.numpy as jnp
 import numpy as np
 import pyscf
 from jsonargparse import CLI, Namespace
-import sys
-sys.path.append("../")
 
 from exchange_correlation.b3lyp import b3lyp
 from electron_repulsion.direct import prepare_electron_repulsion_integrals, electron_repulsion_integrals, ipu_einsum

--- a/notebooks/nanoDFT-demo.ipynb
+++ b/notebooks/nanoDFT-demo.ipynb
@@ -27,7 +27,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -q -r ../requirements_ipu.txt"
+    "%pip install -r ../requirements_ipu.txt\n",
+    "%pip install -e .."
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "pyscf_ipu"
+description = "PySCF  on the Graphcore IPU"
+version = "0.1"
+authors = [
+    { name = "Alex Mathiasen", email = "alexm@graphcore.ai" }
+]
+
+[tool.setuptools]
+packages = [
+   "pyscf_utils", "electron_repulsion", "exchange_correlation", "nanoDFT"
+]
+


### PR DESCRIPTION
This PR adds a `pyproject.toml` file which makes `pyscf_ipu` an installable package.  In particular, it means that we don't explicitly edit sys.path in imported files such as nanoDFT.  It requires a one-time `pip install -e .`, but does not otherwise interfere with development.

Testing:
```
python density_functional_theory.py -methane -backend cpu
python nanoDFT/nanoDFT.py 
jupyter nbconvert --to python notebooks/nanoDFT-demo.ipynb ; python notebooks/nanoDFT-demo.py
```
