### PR TITLE
Fix #23 and #33: compute repetitions for symmetric indices

### DIFF
--- a/nanoDFT/sparse_symmetric_ERI.py
+++ b/nanoDFT/sparse_symmetric_ERI.py
@@ -38,25 +38,38 @@ def inverse_index(value, symmetry):
     i, j = get_i_j(ij)
     k, l = get_i_j(kl)
 
-    N1 = N+1
-    matrix = jnp.array([(i*N1+ j, k*N+ l), (j*N1+ i, k*N+ l), (i*N1+ j, l*N+ k), (j*N1+ i, l*N+ k), 
-                        (k*N1+ l, i*N+ j), (l*N1+ k, i*N+ j), (k*N1+ l, j*N+ i), (l*N1+ k, j*N+ i) ])
+    matrix = jnp.array([(i*N+ j, k*N+ l), (j*N+ i, k*N+ l), (i*N+ j, l*N+ k), (j*N+ i, l*N+ k), 
+                        (k*N+ l, i*N+ j), (l*N+ k, i*N+ j), (k*N+ l, j*N+ i), (l*N+ k, j*N+ i) ])
     v      = matrix[symmetry] 
-    
-    is_in_prev = jnp.any( jnp.all( matrix[:symmetry] == v, axis=-1))
 
-    return (1-is_in_prev) * v[0] - is_in_prev , v[1]
-compute_indices = jax.vmap(inverse_index, in_axes=(0, None))
+    return v[0], v[1]
+vmap_inverse_index = jax.vmap(inverse_index, in_axes=(0, None))
+
+def num_repetitions_fast(value):
+    ij = max_val(value)
+    kl = value - ij*(ij+1)//2
+    i, j = get_i_j(ij)
+    k, l = get_i_j(kl)
+
+    # compute: repetitions = 2^((i==j) + (k==l) + (k==i and l==j or k==j and l==i))
+    repetitions = 2**(
+        jnp.equal(i,j).astype(jnp.int32) + 
+        jnp.equal(k,l).astype(jnp.int32) + 
+        (1 - ((1 - jnp.equal(k,i) * jnp.equal(l,j)) * 
+        (1- jnp.equal(k,j) * jnp.equal(l,i))).astype(jnp.int32))
+    )
+
+    return repetitions
+vmap_num_repetitions_fast = jax.vmap(num_repetitions_fast, in_axes=(0))
 
 def sparse_symmetric_einsum(nonzero_distinct_ERI, nonzero_indices, dm):
     us = jnp.zeros((N**2))
-    dm = jnp.pad(dm, ((0, 0), (0,1)))
     dm = dm.reshape(-1)
 
     # loop over all 8 symmetries 
     for symmetry in range(8):   
         # compute indices for take and segment_sum. 
-        dm_indices, ss_indices = compute_indices(nonzero_indices, symmetry) 
+        dm_indices, ss_indices = vmap_inverse_index(nonzero_indices, symmetry) 
 
         # perform einsum using 8x symmetry and sparsity. 
         dm_values  = jnp.take(dm, dm_indices, axis=0)
@@ -65,6 +78,12 @@ def sparse_symmetric_einsum(nonzero_distinct_ERI, nonzero_indices, dm):
     return us 
 
 backend = "cpu"
+
+# compute number of repetitions per nonzero index
+rep = jax.jit(vmap_num_repetitions_fast, backend=backend)(nonzero_indices)
+
+# pre-scale sparse matrix with relevant number of repetitions
+nonzero_distinct_ERI = nonzero_distinct_ERI / rep
 
 us = jax.jit(sparse_symmetric_einsum, backend=backend)(nonzero_distinct_ERI, nonzero_indices, dm)
 us = np.array(us)


### PR DESCRIPTION
This pull requests adds a fast rule to compute repetitions for the sparse symmetric case, to circumvent compilation issues