### PR TITLE
Sparse symmetric eri

### DIFF
--- a/nanoDFT/compute_indices.cpp
+++ b/nanoDFT/compute_indices.cpp
@@ -40,7 +40,7 @@ ij_pair get_i_j(int32_t val) {
 }
 
 
-class indices : public Vertex {
+class SymmetryIndices : public Vertex {
 public:
   InOut<Vector<int>>  value;
   Input<Vector<int>>  symmetry;

--- a/nanoDFT/compute_indices.cpp
+++ b/nanoDFT/compute_indices.cpp
@@ -1,0 +1,121 @@
+#include <poplar/Vertex.hpp>
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <poplar/HalfFloat.hpp>
+#include <poplar/Vertex.hpp>
+#include "poplar/TileConstants.hpp"
+
+using namespace poplar;
+
+#ifdef __IPU__
+// Use the IPU intrinsics
+#include <ipu_memory_intrinsics>
+#include <ipu_vector_math>
+#define NAMESPACE ipu
+#else
+// Use the std functions
+#include <cmath>
+#define NAMESPACE std
+#endif
+
+int max_val(int N) {
+    float x_candidate_f = (-1 + sqrt(1 + 8 * (float)N)) / 2; 
+    int x_candidate = (int) floor(x_candidate_f);
+    int x = ((x_candidate * (x_candidate + 1)) / 2 <= N) ? x_candidate : x_candidate - 1;
+    return x;
+}
+
+typedef struct {
+    int32_t i;
+    int32_t j;
+} ij_pair;
+
+
+ij_pair get_i_j(int32_t val) {
+    ij_pair result;
+    result.i = max_val(val);
+    result.j = val - result.i * (result.i + 1) / 2;
+    return result;
+}
+
+
+class indices : public Vertex {
+public:
+  InOut<Vector<int>>  value;
+  Input<Vector<int>>  symmetry;
+  Input<Vector<int>>  input_N;
+  Input<Vector<int>>  mask;
+
+  Input<Vector<int>> start;
+  Input<Vector<int>> stop; 
+
+  Output<Vector<int>> out; 
+
+  bool compute() {
+
+    int N = input_N.data()[0];
+
+    for (unsigned int iteration = start.data()[0]; iteration < stop.data()[0]; iteration++){
+    //for (unsigned int iteration = 0; iteration < out.size(); iteration++){
+      int ij = max_val(value.data()[iteration]);
+      int kl = value.data()[iteration] - ij*(ij+1)/2;
+
+      ij_pair pair_ij = get_i_j(ij);
+      ij_pair pair_kl = get_i_j(kl);
+      int i = pair_ij.i;
+      int j = pair_ij.j;
+      int k = pair_kl.i;
+      int l = pair_kl.j;
+
+      switch (symmetry.data()[0]) {
+        //dm_indices_func_J = lambda i,j,k,l,symmetry: jnp.array([i*N+j, j*N+i, i*N+j, j*N+i, k*N+l, l*N+k, k*N+l, l*N+k])[symmetry]
+        //i*N+j, j*N+i, i*N+j, j*N+i, k*N+l, l*N+k, k*N+l, l*N+k
+        case 0: { out[iteration] = i*N+j; break; }
+        case 1: { out[iteration] = j*N+i; break; }
+        case 2: { out[iteration] = i*N+j; break; }
+        case 3: { out[iteration] = j*N+i; break; }
+        case 4: { out[iteration] = k*N+l; break; }
+        case 5: { out[iteration] = l*N+k; break; }
+        case 6: { out[iteration] = k*N+l; break; }
+        case 7: { out[iteration] = l*N+k; break; }
+
+
+        //ss_indices_func_J = lambda i,j,k,l,symmetry: jnp.array([k*N+l, k*N+l, l*N+k, l*N+k, i*N+j, i*N+j, j*N+i, j*N+i])[symmetry]
+        case 8: { out[iteration]  = k*N+l; break; }
+        case 9: { out[iteration]  = k*N+l; break; }
+        case 10: { out[iteration] = l*N+k; break; }
+        case 11: { out[iteration] = l*N+k; break; }
+        case 12: { out[iteration] = i*N+j; break; }
+        case 13: { out[iteration] = i*N+j; break; }
+        case 14: { out[iteration] = j*N+i; break; }
+        case 15: { out[iteration] = j*N+i; break; }
+
+
+        //dm_indices_func_K = lambda i,j,k,l,symmetry: jnp.array([k*N+j, k*N+i, l*N+j, l*N+i, i*N+l, i*N+k, j*N+l, j*N+k])[symmetry]
+        case 16: { out[iteration] = k*N+j; break; }
+        case 17: { out[iteration] = k*N+i; break; }
+        case 18: { out[iteration] = l*N+j; break; }
+        case 19: { out[iteration] = l*N+i; break; }
+        case 20: { out[iteration] = i*N+l; break; }
+        case 21: { out[iteration] = i*N+k; break; }
+        case 22: { out[iteration] = j*N+l; break; }
+        case 23: { out[iteration] = j*N+k; break; }
+
+
+        //ss_indices_func_K = lambda i,j,k,l,symmetry: jnp.array([i*N+l, j*N+l, i*N+k, j*N+k, k*N+j, l*N+j, k*N+i, l*N+i])[symmetry]
+        case 24: { out[iteration] = i*N+l; break; }
+        case 25: { out[iteration] = j*N+l; break; }
+        case 26: { out[iteration] = i*N+k; break; }
+        case 27: { out[iteration] = j*N+k; break; }
+        case 28: { out[iteration] = k*N+j; break; }
+        case 29: { out[iteration] = l*N+j; break; }
+        case 30: { out[iteration] = k*N+i; break; }
+        case 31: { out[iteration] = l*N+i; break; }
+      }
+    }
+    return true ;
+  }
+
+};
+

--- a/nanoDFT/experimental_pmap_nanoDFT.py
+++ b/nanoDFT/experimental_pmap_nanoDFT.py
@@ -110,9 +110,12 @@ def get_JK(density_matrix, ERI, opts, mol):
             mult = ERI.reshape(N**2//16, N**2) @ density_matrix.reshape(N**2, 1)
             diff_JK  = jax.lax.all_gather(mult, axis_name="p")
         else: 
-            mult = sparse_mult(ERI, density_matrix.reshape(N**2, -1)) # each of these guys computes on inner product? 
-            diff_JK = jax.lax.psum(mult, axis_name="p")
-            diff_JK = diff_JK.reshape(N, N)
+            #mult = sparse_mult(ERI, density_matrix.reshape(N**2, -1)) # each of these guys computes on inner product? 
+            #diff_JK = jax.lax.psum(mult, axis_name="p")
+            #diff_JK = diff_JK.reshape(N, N)
+            from sparse_symmetric_ERI import sparse_symmetric_einsum
+            mask = jnp.ones(1)
+            diff_JK = sparse_symmetric_einsum(ERI[0], ERI[1], density_matrix, mask, opts.backend)
 
     else:
         J = jnp.einsum('ijkl,ji->kl', ERI, density_matrix)                                       # (N, N)
@@ -167,16 +170,16 @@ def init_dft_tensors_cpu(mol, opts, DIIS_iters=9):
     L_inv           = np.linalg.inv(np.linalg.cholesky(O))          # (N,N)
     #if opts.backend != "ipu": ERI = mol.intor("int2e_sph")          # (N,N,N,N)=(66,66,66,66) for C6H6.
     #else:                     ERI = None # will be computed on device
-    ERI = mol.intor("int2e_sph")
+    ERI = 0 #mol.intor("int2e_sph")
 
-    if opts.backend == "ipu": 
+    '''if opts.backend == "ipu": 
         #ERI[ERI<1e-10] = 0 # warning 
         print(np.sum(np.abs(ERI)>1e-10)/ERI.size)
         M1 = ERI.reshape(N**2, N**2)
         M2 = ERI.transpose(1,2,0,3).reshape(N**2, N**2)
         ERI = M1-M2/2*HYB_B3LYP
         print(np.sum(np.abs(ERI)>1e-10)/ERI.size)
-        #print(ERI.shape)
+        #print(ERI.shape)'''
 
     input_floats, input_ints = 0, 0 #prepare_electron_repulsion_integrals(mol)[:2]
     mask = np.concatenate([np.ones(n_electrons_half), np.zeros(N-n_electrons_half)])
@@ -215,28 +218,56 @@ def nanoDFT(mol, opts):
     # we can have "ipus" argument instead, or pod16 as backend? 
     if opts.backend == "ipu":
         jitted_nanoDFT = jax.pmap(partial(_nanoDFT, opts=opts, mol=mol), axis_name="p", backend=opts.backend,
-        in_axes=(None, None, None, None, None, None, None, None, None, None, None, (None, None, None), 0, 0, [0, 0, 0]))
+        in_axes=(None, None, None, None, None, None, None, None, None, None, None, (None, None, None), 0, 0, [0, 0]))
 
-        def sparse_representation(ERI):
-            rows, cols = np.nonzero(ERI)
-            values     = ERI[rows, cols]
-            return rows, cols, values 
+        if False: 
+            def sparse_representation(ERI):
+                rows, cols = np.nonzero(ERI)
+                values     = ERI[rows, cols]
+                return rows, cols, values 
 
-        # ERI = tensors[6]  # ERI is just the 6th element in tensors
-        sparse_ERI = sparse_representation(ERI)
-        remainder = sparse_ERI[-1].shape[0] % 16
-        if remainder != 0:
-            sparse_ERI = [np.pad(a, (0, -remainder+16)) for a in sparse_ERI]
-        sparse_ERI = [a.reshape(16, -1) for a in sparse_ERI]
-        # tensors[6] = sparse_ERI
+            # ERI = tensors[6]  # ERI is just the 6th element in tensors
+            sparse_ERI = sparse_representation(ERI)
+            remainder = sparse_ERI[-1].shape[0] % 16
+            if remainder != 0:
+                sparse_ERI = [np.pad(a, (0, -remainder+16)) for a in sparse_ERI]
+            sparse_ERI = [a.reshape(16, -1) for a in sparse_ERI]
+            # tensors[6] = sparse_ERI
+        else:
+            from sparse_symmetric_ERI import vmap_num_repetitions_fast
+            import time 
+            start = time.time()
+            distinct_ERI         = mol.intor("int2e_sph", aosym="s8")
+            nonzero_indices      = np.nonzero(distinct_ERI)[0].astype(np.int32)
+            nonzero_distinct_ERI = distinct_ERI[nonzero_indices].astype(np.float32)
+            print("compute eri normalization ", time.time()-start)
+            rep = jax.jit(vmap_num_repetitions_fast, backend="cpu")(nonzero_indices)
+            print("perform normalization ", time.time()-start)
+            nonzero_distinct_ERI = nonzero_distinct_ERI / rep
+
+            print("pad remainder ", time.time()-start)
+            print(nonzero_distinct_ERI.shape, nonzero_indices.shape)
+            batches = 64 # perhaps make 10 batches? 
+            nipu = 16
+            remainder = nonzero_indices.shape[0] % (nipu*batches)
+            if remainder != 0:
+                nonzero_indices = np.pad(nonzero_indices, (0,nipu*batches-remainder))
+                nonzero_distinct_ERI = np.pad(nonzero_distinct_ERI, (0,nipu*batches-remainder))
+
+            print("reshape to 16 IPUs pmap", time.time()-start)
+            nonzero_indices = nonzero_indices.reshape(nipu, batches, -1)
+            nonzero_distinct_ERI = nonzero_distinct_ERI.reshape(nipu, batches, -1)
+            print(nonzero_indices.shape)
+            print(nonzero_distinct_ERI.shape)
+
+            sparse_ERI = [nonzero_distinct_ERI, nonzero_indices]
 
         tensors.append(sharded_grid_AO)
         tensors.append(sharded_grid_weights)
         tensors.append(sparse_ERI)
 
-
         vals = jitted_nanoDFT(*tensors)
-        logged_matrices, H_core, logged_energies = [np.asarray(a).astype(np.float64)[0] for a in vals] # Ensure CPU
+        logged_matrices, H_core, logged_energies = [np.asarray(a[0]).astype(np.float64) for a in vals] # Ensure CPU
     else: 
         jitted_nanoDFT = jax.jit(partial(_nanoDFT, opts=opts, mol=mol), backend=opts.backend)
         tensors = tensors + (sharded_grid_AO,)
@@ -520,6 +551,12 @@ def nanoDFT_options(
         # mol_str = [["H", (0, 0, n) for n in range(8*2*2*2)]]    # N=128
         # mol_str = [["H", (0, 0, n) for n in range(8*2*2*2*2)]]  # N=256
         basis = "6-31g"
+    elif mol_str == "cgrid": 
+        mol_str = [["C", (0, i*1.5, j*1.5)] for i in range(4) for j in range(4)]
+        #mol_str = [["C", (0, i*1.5, j*1.5)] for i in range(5) for j in range(5)]
+        #mol_str = [["C", (0, i*1.5, j*1.5)] for i in range(6) for j in range(6)]
+        #mol_str = [["C", (0, i*1.5, j*1.5)] for i in range(7) for j in range(7)] 
+    
     args = locals()
     mol_str = args["mol_str"]
     del args["mol_str"]

--- a/nanoDFT/experimental_pmap_nanoDFT.py
+++ b/nanoDFT/experimental_pmap_nanoDFT.py
@@ -106,17 +106,9 @@ def get_JK(density_matrix, ERI, opts, mol):
         return jax.ops.segment_sum(prod, rows, N**2) 
 
     if opts.backend == "ipu":
-        if False:
-            mult = ERI.reshape(N**2//16, N**2) @ density_matrix.reshape(N**2, 1)
-            diff_JK  = jax.lax.all_gather(mult, axis_name="p")
-        else: 
-            #mult = sparse_mult(ERI, density_matrix.reshape(N**2, -1)) # each of these guys computes on inner product? 
-            #diff_JK = jax.lax.psum(mult, axis_name="p")
-            #diff_JK = diff_JK.reshape(N, N)
-            from sparse_symmetric_ERI import sparse_symmetric_einsum
-            mask = jnp.ones(1)
-            diff_JK = sparse_symmetric_einsum(ERI[0], ERI[1], density_matrix, mask, opts.backend)
-
+        from sparse_symmetric_ERI import sparse_symmetric_einsum
+        mask = jnp.ones(1)
+        diff_JK = sparse_symmetric_einsum(ERI[0], ERI[1], density_matrix, mask, opts.backend)
     else:
         J = jnp.einsum('ijkl,ji->kl', ERI, density_matrix)                                       # (N, N)
         K = jnp.einsum('ijkl,jk->il', ERI, density_matrix)                                       # (N, N)
@@ -170,16 +162,7 @@ def init_dft_tensors_cpu(mol, opts, DIIS_iters=9):
     L_inv           = np.linalg.inv(np.linalg.cholesky(O))          # (N,N)
     #if opts.backend != "ipu": ERI = mol.intor("int2e_sph")          # (N,N,N,N)=(66,66,66,66) for C6H6.
     #else:                     ERI = None # will be computed on device
-    ERI = 0 #mol.intor("int2e_sph")
-
-    '''if opts.backend == "ipu": 
-        #ERI[ERI<1e-10] = 0 # warning 
-        print(np.sum(np.abs(ERI)>1e-10)/ERI.size)
-        M1 = ERI.reshape(N**2, N**2)
-        M2 = ERI.transpose(1,2,0,3).reshape(N**2, N**2)
-        ERI = M1-M2/2*HYB_B3LYP
-        print(np.sum(np.abs(ERI)>1e-10)/ERI.size)
-        #print(ERI.shape)'''
+    ERI = 0# todo: move ERI defined later in here. 
 
     input_floats, input_ints = 0, 0 #prepare_electron_repulsion_integrals(mol)[:2]
     mask = np.concatenate([np.ones(n_electrons_half), np.zeros(N-n_electrons_half)])
@@ -220,47 +203,34 @@ def nanoDFT(mol, opts):
         jitted_nanoDFT = jax.pmap(partial(_nanoDFT, opts=opts, mol=mol), axis_name="p", backend=opts.backend,
         in_axes=(None, None, None, None, None, None, None, None, None, None, None, (None, None, None), 0, 0, [0, 0]))
 
-        if False: 
-            def sparse_representation(ERI):
-                rows, cols = np.nonzero(ERI)
-                values     = ERI[rows, cols]
-                return rows, cols, values 
+        
+        from sparse_symmetric_ERI import vmap_num_repetitions_fast
+        import time 
+        start = time.time()
+        distinct_ERI         = mol.intor("int2e_sph", aosym="s8")
+        nonzero_indices      = np.nonzero(distinct_ERI)[0].astype(np.int32)
+        nonzero_distinct_ERI = distinct_ERI[nonzero_indices].astype(np.float32)
+        print("compute eri normalization ", time.time()-start)
+        rep = jax.jit(vmap_num_repetitions_fast, backend="cpu")(nonzero_indices)
+        print("perform normalization ", time.time()-start)
+        nonzero_distinct_ERI = nonzero_distinct_ERI / rep
 
-            # ERI = tensors[6]  # ERI is just the 6th element in tensors
-            sparse_ERI = sparse_representation(ERI)
-            remainder = sparse_ERI[-1].shape[0] % 16
-            if remainder != 0:
-                sparse_ERI = [np.pad(a, (0, -remainder+16)) for a in sparse_ERI]
-            sparse_ERI = [a.reshape(16, -1) for a in sparse_ERI]
-            # tensors[6] = sparse_ERI
-        else:
-            from sparse_symmetric_ERI import vmap_num_repetitions_fast
-            import time 
-            start = time.time()
-            distinct_ERI         = mol.intor("int2e_sph", aosym="s8")
-            nonzero_indices      = np.nonzero(distinct_ERI)[0].astype(np.int32)
-            nonzero_distinct_ERI = distinct_ERI[nonzero_indices].astype(np.float32)
-            print("compute eri normalization ", time.time()-start)
-            rep = jax.jit(vmap_num_repetitions_fast, backend="cpu")(nonzero_indices)
-            print("perform normalization ", time.time()-start)
-            nonzero_distinct_ERI = nonzero_distinct_ERI / rep
+        print("pad remainder ", time.time()-start)
+        print(nonzero_distinct_ERI.shape, nonzero_indices.shape)
+        batches = 64 # perhaps make 10 batches? 
+        nipu = 16
+        remainder = nonzero_indices.shape[0] % (nipu*batches)
+        if remainder != 0:
+            nonzero_indices = np.pad(nonzero_indices, (0,nipu*batches-remainder))
+            nonzero_distinct_ERI = np.pad(nonzero_distinct_ERI, (0,nipu*batches-remainder))
 
-            print("pad remainder ", time.time()-start)
-            print(nonzero_distinct_ERI.shape, nonzero_indices.shape)
-            batches = 64 # perhaps make 10 batches? 
-            nipu = 16
-            remainder = nonzero_indices.shape[0] % (nipu*batches)
-            if remainder != 0:
-                nonzero_indices = np.pad(nonzero_indices, (0,nipu*batches-remainder))
-                nonzero_distinct_ERI = np.pad(nonzero_distinct_ERI, (0,nipu*batches-remainder))
+        print("reshape to 16 IPUs pmap", time.time()-start)
+        nonzero_indices = nonzero_indices.reshape(nipu, batches, -1)
+        nonzero_distinct_ERI = nonzero_distinct_ERI.reshape(nipu, batches, -1)
+        print(nonzero_indices.shape)
+        print(nonzero_distinct_ERI.shape)
 
-            print("reshape to 16 IPUs pmap", time.time()-start)
-            nonzero_indices = nonzero_indices.reshape(nipu, batches, -1)
-            nonzero_distinct_ERI = nonzero_distinct_ERI.reshape(nipu, batches, -1)
-            print(nonzero_indices.shape)
-            print(nonzero_distinct_ERI.shape)
-
-            sparse_ERI = [nonzero_distinct_ERI, nonzero_indices]
+        sparse_ERI = [nonzero_distinct_ERI, nonzero_indices]
 
         tensors.append(sharded_grid_AO)
         tensors.append(sharded_grid_weights)

--- a/nanoDFT/sparse_symmetric_ERI.py
+++ b/nanoDFT/sparse_symmetric_ERI.py
@@ -7,10 +7,13 @@ jax.config.update('jax_enable_x64', False)
 import argparse 
 parser = argparse.ArgumentParser(prog='', description='', epilog='')
 parser.add_argument('-backend', default="cpu"),
+parser.add_argument('-natm', default=3),
 args = parser.parse_args()
 backend = args.backend 
 
-mol = pyscf.gto.Mole(atom="".join(f"C 0 {1.54*j} {1.54*i};" for i in range(3) for j in range(4))) 
+natm = int(args.natm) 
+
+mol = pyscf.gto.Mole(atom="".join(f"C 0 {1.54*j} {1.54*i};" for i in range(natm) for j in range(natm))) 
 mol.build()
 dense_ERI = mol.intor("int2e_sph", aosym="s1")
 distinct_ERI = mol.intor("int2e_sph", aosym="s8")
@@ -22,45 +25,26 @@ J = np.einsum("ijkl,ji->kl", dense_ERI, dm)
 K = np.einsum("ijkl,jk->il", dense_ERI, dm)
 truth = J - K / 2 * HYB_B3LYP
 
-nonzero_indices      = np.nonzero(distinct_ERI)[0]
-nonzero_distinct_ERI = distinct_ERI[nonzero_indices]
+nonzero_indices      = np.nonzero(distinct_ERI)[0].astype(np.int32)
+nonzero_distinct_ERI = distinct_ERI[nonzero_indices].astype(np.float32)
 print("[%i]"%mol.nao_nr())
-print("dense: ", dense_ERI.shape, dense_ERI.nbytes/10**6/2)
-print("sparse: ", distinct_ERI.shape, distinct_ERI.nbytes/10**6/2)
-print("sparse+symmetric: ", nonzero_distinct_ERI.shape, nonzero_distinct_ERI.nbytes/10**6/2)
+print("dense: ", dense_ERI.shape, dense_ERI.nbytes/10**6)
+print("sparse: ", distinct_ERI.shape, distinct_ERI.nbytes/10**6)
+print("sparse+symmetric: ", nonzero_distinct_ERI.shape, nonzero_distinct_ERI.nbytes/10**6)
+
+# todo: check if squareroot causes problems (as seen before). can mitigate using following trick! 
+def sqrt(x): return jnp.exp(1/2*jnp.log(x))
 
 def max_val(N):
-    x_candidate = (-1 + jnp.sqrt(1 + 8*N)) / 2
-    x_candidate = jnp.floor(x_candidate)
+    x_candidate = (-1 + jnp.sqrt(1 + 8*N)) // 2 # i think above trick leads to overflow! 
+    x_candidate = (x_candidate).astype(jnp.int32) # this cast works as floor 
     x = jnp.where(x_candidate * (x_candidate + 1) // 2 <= N, x_candidate, x_candidate - 1)
-    return x.astype(jnp.int32)
+    return x
 max_vals  = jax.vmap(max_val)
 def get_i_j(val):
     i = max_val(val)
     j = val - i*(i+1)//2
     return i, j
-def inverse_index_J(value, symmetry): 
-    ij = max_val(value)
-    kl = value - ij*(ij+1)//2
-    i, j = get_i_j(ij)
-    k, l = get_i_j(kl)
-    matrix = [(i*N+ j, k*N+ l), (j*N+ i, k*N+ l), (i*N+ j, l*N+ k), (j*N+ i, l*N+ k),  
-                        (k*N+ l, i*N+ j), (l*N+ k, i*N+ j), (k*N+ l, j*N+ i), (l*N+ k, j*N+ i) ]
-    v      = matrix[symmetry] 
-    return v[0], v[1]
-vmap_inverse_index_J = jax.vmap(inverse_index_J, in_axes=(0, None))
-
-def inverse_index_K(value, symmetry): 
-    ij = max_val(value)
-    kl = value - ij*(ij+1)//2
-    i, j = get_i_j(ij)
-    k, l = get_i_j(kl)
-    # same as _J but "flip 0'th and 2'nd column"
-    matrix = [(k*N+ j, i*N+ l), (k*N+ i, j*N+ l), (l*N+ j, i*N+ k), (l*N+ i, j*N+ k), 
-              (i*N+ l, k*N+ j), (i*N+ k, l*N+ j), (j*N+ l, k*N+ i), (j*N+ k, l*N+ i) ]
-    v      = matrix[symmetry] 
-    return v[0], v[1]
-vmap_inverse_index_K = jax.vmap(inverse_index_K, in_axes=(0, None))
 
 def num_repetitions_fast(value):
     ij = max_val(value)
@@ -79,29 +63,127 @@ def num_repetitions_fast(value):
     return repetitions
 vmap_num_repetitions_fast = jax.vmap(num_repetitions_fast, in_axes=(0))
 
-def sparse_symmetric_einsum(nonzero_distinct_ERI, nonzero_indices, dm):
-    diff_JK = jnp.zeros((N**2))
-    dm = dm.reshape(-1)
+def inverse_index_J_dm(value, symmetry, mask, f): 
+    ij = max_val(value*mask[0])
+    kl = value - ij*(ij+1)//2
+    i, j = get_i_j(ij)
+    k, l = get_i_j(kl)
 
-    # loop over all 8 symmetries 
+    v      = f(i,j,k,l,symmetry) 
+    return v
+def inverse_index_J_ss(value, symmetry, mask): 
+    ij = max_val(value*mask[0])
+    kl = value - ij*(ij+1)//2
+    i, j = get_i_j(ij)
+    k, l = get_i_j(kl)
+    matrix = [k*N+ l, k*N+ l, l*N+ k, l*N+ k ,  i*N+ j, i*N+ j, j*N+ i, j*N+ i ]
+    v      = matrix[symmetry] 
+    return  v
+get_ijkl = jax.vmap(inverse_index_J_dm, in_axes=(0, None, None, None))
+vmap_inverse_index_J_ss = jax.vmap(inverse_index_J_ss, in_axes=(0, None, None))
+
+value =jnp.ones(1, dtype=jnp.int32)*10
+mask = jnp.ones(1, dtype=jnp.int32)
+symmetry = 2
+
+import os.path as osp
+from tessellate_ipu import create_ipu_tile_primitive, ipu_cycle_count, tile_map, tile_put_sharded, tile_put_replicated
+from functools import partial 
+
+
+@partial(jax.jit, backend="ipu")
+def _vmap_inverse_index_J_dm(value, symmetry, N, mask):
+    vertex_filename  = osp.join(osp.dirname(__file__), "compute_indices.cpp")
+    compute_indices= create_ipu_tile_primitive(
+            "indices",
+            "indices",
+            inputs=["value", "symmetry", "input_N", "mask", "start", "stop"],
+            outputs={"value": 0},
+            gp_filename=vertex_filename,
+            perf_estimate=100,
+    )
+
+    if value.shape[0] <= (1472-1)*6: 
+        tiles = tuple((np.arange(0,value.shape[0]) % (value.shape[0]//6) + 1).astype(np.int32).tolist())
+        symmetry = jnp.array(symmetry, dtype=jnp.int32).reshape(1,)
+        value = tile_put_sharded(value, tiles)
+        symmetry = tile_put_replicated(symmetry,   tiles)
+        N  = tile_put_replicated(N,   tiles)
+        mask  = tile_put_replicated(mask,   tiles)
+        index = tile_map(compute_indices, value, symmetry, N, mask )
+
+    else: 
+        # loop around them.
+        size = value.shape[0]
+        print(value.shape)
+        total_threads = (1472-1) * 6 
+        remainder = size % total_threads
+        if remainder != 0: 
+            value = jnp.pad(value, (0, total_threads-remainder))
+
+        tiles = tuple((np.arange(0,total_threads) % (1471) + 1).astype(np.int32).tolist())
+        value = value.reshape(total_threads, -1) 
+        value = tile_put_sharded(value, tiles)
+        symmetry = jnp.array(symmetry, dtype=jnp.int32).reshape(1,)
+        symmetry = tile_put_replicated(symmetry,   tiles)
+        mask     = tile_put_replicated(mask,   tiles)
+        N        = tile_put_replicated(N,   tiles)
+        start    = tile_put_replicated(0,   tiles)
+        stop     = tile_put_replicated(value.shape[1],   tiles)
+
+        step_size = 1 
+        print(size//total_threads+1, step_size)
+        value = tile_map(compute_indices, value, symmetry, N, mask, start, stop  ) 
+
+    return value.array.reshape(-1)[:size]
+
+def inverse_index_K_dm(value, symmetry, mask): 
+    ij = max_val(value*mask[0])
+    kl = value - ij*(ij+1)//2
+    i, j = get_i_j(ij) 
+    k, l = get_i_j(kl)
+    # same as _J but "flip 0'th and 2'nd column"
+    matrix = [k*N+ j, k*N+ i, l*N+ j, l*N+ i, i*N+ l, i*N+ k, j*N+ l, j*N+ k ]
+    v      = matrix[symmetry] 
+    return v
+def inverse_index_K_ss(value, symmetry, mask): 
+    ij = max_val(value*mask[0])
+    kl = value - ij*(ij+1)//2
+    i, j = get_i_j(ij)
+    k, l = get_i_j(kl)
+    # same as _J but "flip 0'th and 2'nd column"
+    matrix = [i*N+ l, j*N+ l, i*N+ k, j*N+ k, k*N+ j, l*N+ j, k*N+ i, l*N+ i ]
+    v      = matrix[symmetry] 
+    return  v
+vmap_inverse_index_K_dm = jax.vmap(inverse_index_K_dm, in_axes=(0, None, None))
+vmap_inverse_index_K_ss = jax.vmap(inverse_index_K_ss, in_axes=(0, None, None))
+
+def sparse_symmetric_einsum(nonzero_distinct_ERI, nonzero_indices, dm, mask, diff_JK):
+    mask      = (mask-1)*jnp.sum(diff_JK)*jnp.sum(dm) + mask 
+
+    dm_indices_func_J = lambda i,j,k,l,symmetry: jnp.array([i*N+ j, j*N+ i, i*N+ j, j*N+ i, k*N+ l, l*N+ k, k*N+ l, l*N+ k])[symmetry]
+    ss_indices_func_J = lambda i,j,k,l,symmetry: jnp.array([k*N+ l, k*N+ l, l*N+ k, l*N+ k, i*N+ j, i*N+ j, j*N+ i, j*N+ i])[symmetry]
+    dm_indices_func_K = lambda i,j,k,l,symmetry: jnp.array([k*N+ j, k*N+ i, l*N+ j, l*N+ i, i*N+ l, i*N+ k, j*N+ l, j*N+ k])[symmetry]
+    ss_indices_func_K = lambda i,j,k,l,symmetry: jnp.array([i*N+ l, j*N+ l, i*N+ k, j*N+ k, k*N+ j, l*N+ j, k*N+ i, l*N+ i])[symmetry]
+
     for symmetry in range(8):   
-        # compute indices for take and segment_sum. 
-        dm_indices, ss_indices = vmap_inverse_index_J(nonzero_indices, symmetry)  # may introduce additional overhead? 
-
-        # perform einsum using 8x symmetry and sparsity. 
-        dm_values = jnp.take(dm, dm_indices, axis=0)
-        prod      = dm_values * nonzero_distinct_ERI 
-        diff_JK   = diff_JK + jax.ops.segment_sum(prod, ss_indices, N**2)
-                
-    # loop over all 8 symmetries 
-    for symmetry in range(8):   
-        # compute indices for take and segment_sum. 
-        dm_indices, ss_indices = vmap_inverse_index_K(nonzero_indices, symmetry) 
-
-        # perform einsum using 8x symmetry and sparsity. 
-        dm_values = jnp.take(dm, dm_indices, axis=0)
-        prod      = dm_values * nonzero_distinct_ERI 
-        diff_JK   = diff_JK - jax.ops.segment_sum(prod, ss_indices, N**2) / 2 * HYB_B3LYP 
+        # J matrix 
+        dm_indices = get_ijkl(nonzero_indices, symmetry, mask, dm_indices_func_J)  
+        dm_values  = jnp.take(dm*mask, dm_indices, axis=0)
+        prod       = dm_values * nonzero_distinct_ERI* mask 
+        mask       = (mask-1)*jnp.sum(prod) + mask 
+        ss_indices = get_ijkl(nonzero_indices, symmetry, mask, ss_indices_func_J) 
+        diff_JK    = diff_JK + jax.ops.segment_sum(prod, ss_indices, N**2) 
+        mask       = (mask-1)*jnp.sum(diff_JK) + mask 
+            
+        # K matrix 
+        dm_indices = get_ijkl(nonzero_indices, symmetry, mask, dm_indices_func_K) 
+        dm_values  = jnp.take(dm*mask, dm_indices, axis=0)
+        prod       = dm_values * nonzero_distinct_ERI*mask
+        mask       = (mask-1)*jnp.sum(prod) + mask 
+        ss_indices = get_ijkl(nonzero_indices, symmetry, mask, ss_indices_func_K) 
+        diff_JK    = diff_JK - jax.ops.segment_sum(prod, ss_indices, N**2) / 2 * HYB_B3LYP 
+        mask       = (mask-1)*jnp.sum(diff_JK) + mask 
 
     return diff_JK
 
@@ -109,7 +191,10 @@ def sparse_symmetric_einsum(nonzero_distinct_ERI, nonzero_indices, dm):
 rep = jax.jit(vmap_num_repetitions_fast, backend="cpu")(nonzero_indices)
 nonzero_distinct_ERI = nonzero_distinct_ERI / rep
 
-diff_JK = jax.jit(jax.checkpoint(sparse_symmetric_einsum), backend=backend)(nonzero_distinct_ERI, nonzero_indices, dm)
+mask = np.ones(1)
+dm = dm.reshape(-1)
+diff_JK = np.zeros(dm.shape)
+diff_JK = jax.jit(sparse_symmetric_einsum, backend=backend)(nonzero_distinct_ERI, nonzero_indices, dm, mask, diff_JK)
 diff_JK = np.array(diff_JK)
 
 diff_JK = diff_JK.reshape(N, N)

--- a/nanoDFT/sparse_symmetric_ERI.py
+++ b/nanoDFT/sparse_symmetric_ERI.py
@@ -178,6 +178,7 @@ if __name__ == "__main__":
     print("----------\n")
 
     # write code that profiles get_indices/take/segment_sum independently. 
+    # TODO: fix broken test below. add seperate test for get_indices/np.take and segment_sum, potentially with custom poplar implementations
     if args.prof: 
         symmetry = 7 
         dm_indices = get_ijkl(nonzero_indices, symmetry, mask, dm_indices_func_J)  

--- a/nanoDFT/sparse_symmetric_ERI.py
+++ b/nanoDFT/sparse_symmetric_ERI.py
@@ -1,24 +1,33 @@
-from tqdm import tqdm 
 import pyscf 
 import numpy as np 
 import jax 
 import jax.numpy as jnp 
 jax.config.update('jax_platform_name', "cpu")
 jax.config.update('jax_enable_x64', False) 
+import argparse 
+parser = argparse.ArgumentParser(prog='', description='', epilog='')
+parser.add_argument('-backend', default="cpu"),
+args = parser.parse_args()
+backend = args.backend 
 
-mol = pyscf.gto.Mole(atom="".join(f"C 0 0 {1.54*i};" for i in range(4))) 
-
+mol = pyscf.gto.Mole(atom="".join(f"C 0 {1.54*j} {1.54*i};" for i in range(3) for j in range(4))) 
 mol.build()
 dense_ERI = mol.intor("int2e_sph", aosym="s1")
 distinct_ERI = mol.intor("int2e_sph", aosym="s8")
 N = mol.nao_nr()
 dm = pyscf.scf.hf.init_guess_by_minao(mol)         
-truth = np.einsum("ijkl,ji->kl", dense_ERI, dm)
+HYB_B3LYP = 0.2
+scale = HYB_B3LYP/2
+J = np.einsum("ijkl,ji->kl", dense_ERI, dm)
+K = np.einsum("ijkl,jk->il", dense_ERI, dm)
+truth = J - K / 2 * HYB_B3LYP
 
 nonzero_indices      = np.nonzero(distinct_ERI)[0]
 nonzero_distinct_ERI = distinct_ERI[nonzero_indices]
-
-us = np.zeros((N,N))
+print("[%i]"%mol.nao_nr())
+print("dense: ", dense_ERI.shape, dense_ERI.nbytes/10**6/2)
+print("sparse: ", distinct_ERI.shape, distinct_ERI.nbytes/10**6/2)
+print("sparse+symmetric: ", nonzero_distinct_ERI.shape, nonzero_distinct_ERI.nbytes/10**6/2)
 
 def max_val(N):
     x_candidate = (-1 + jnp.sqrt(1 + 8*N)) / 2
@@ -26,24 +35,32 @@ def max_val(N):
     x = jnp.where(x_candidate * (x_candidate + 1) // 2 <= N, x_candidate, x_candidate - 1)
     return x.astype(jnp.int32)
 max_vals  = jax.vmap(max_val)
-
 def get_i_j(val):
     i = max_val(val)
     j = val - i*(i+1)//2
     return i, j
-
-def inverse_index(value, symmetry): 
+def inverse_index_J(value, symmetry): 
     ij = max_val(value)
     kl = value - ij*(ij+1)//2
     i, j = get_i_j(ij)
     k, l = get_i_j(kl)
-
-    matrix = jnp.array([(i*N+ j, k*N+ l), (j*N+ i, k*N+ l), (i*N+ j, l*N+ k), (j*N+ i, l*N+ k), 
-                        (k*N+ l, i*N+ j), (l*N+ k, i*N+ j), (k*N+ l, j*N+ i), (l*N+ k, j*N+ i) ])
+    matrix = [(i*N+ j, k*N+ l), (j*N+ i, k*N+ l), (i*N+ j, l*N+ k), (j*N+ i, l*N+ k),  
+                        (k*N+ l, i*N+ j), (l*N+ k, i*N+ j), (k*N+ l, j*N+ i), (l*N+ k, j*N+ i) ]
     v      = matrix[symmetry] 
-
     return v[0], v[1]
-vmap_inverse_index = jax.vmap(inverse_index, in_axes=(0, None))
+vmap_inverse_index_J = jax.vmap(inverse_index_J, in_axes=(0, None))
+
+def inverse_index_K(value, symmetry): 
+    ij = max_val(value)
+    kl = value - ij*(ij+1)//2
+    i, j = get_i_j(ij)
+    k, l = get_i_j(kl)
+    # same as _J but "flip 0'th and 2'nd column"
+    matrix = [(k*N+ j, i*N+ l), (k*N+ i, j*N+ l), (l*N+ j, i*N+ k), (l*N+ i, j*N+ k), 
+              (i*N+ l, k*N+ j), (i*N+ k, l*N+ j), (j*N+ l, k*N+ i), (j*N+ k, l*N+ i) ]
+    v      = matrix[symmetry] 
+    return v[0], v[1]
+vmap_inverse_index_K = jax.vmap(inverse_index_K, in_axes=(0, None))
 
 def num_repetitions_fast(value):
     ij = max_val(value)
@@ -63,34 +80,41 @@ def num_repetitions_fast(value):
 vmap_num_repetitions_fast = jax.vmap(num_repetitions_fast, in_axes=(0))
 
 def sparse_symmetric_einsum(nonzero_distinct_ERI, nonzero_indices, dm):
-    us = jnp.zeros((N**2))
+    diff_JK = jnp.zeros((N**2))
     dm = dm.reshape(-1)
 
     # loop over all 8 symmetries 
     for symmetry in range(8):   
         # compute indices for take and segment_sum. 
-        dm_indices, ss_indices = vmap_inverse_index(nonzero_indices, symmetry) 
+        dm_indices, ss_indices = vmap_inverse_index_J(nonzero_indices, symmetry)  # may introduce additional overhead? 
 
         # perform einsum using 8x symmetry and sparsity. 
-        dm_values  = jnp.take(dm, dm_indices, axis=0)
-        prod       = dm_values * nonzero_distinct_ERI 
-        us        += jax.ops.segment_sum(prod, ss_indices, N**2)  
-    return us 
+        dm_values = jnp.take(dm, dm_indices, axis=0)
+        prod      = dm_values * nonzero_distinct_ERI 
+        diff_JK   = diff_JK + jax.ops.segment_sum(prod, ss_indices, N**2)
+                
+    # loop over all 8 symmetries 
+    for symmetry in range(8):   
+        # compute indices for take and segment_sum. 
+        dm_indices, ss_indices = vmap_inverse_index_K(nonzero_indices, symmetry) 
 
-backend = "cpu"
+        # perform einsum using 8x symmetry and sparsity. 
+        dm_values = jnp.take(dm, dm_indices, axis=0)
+        prod      = dm_values * nonzero_distinct_ERI 
+        diff_JK   = diff_JK - jax.ops.segment_sum(prod, ss_indices, N**2) / 2 * HYB_B3LYP 
 
-# compute number of repetitions per nonzero index
-rep = jax.jit(vmap_num_repetitions_fast, backend=backend)(nonzero_indices)
+    return diff_JK
 
-# pre-scale sparse matrix with relevant number of repetitions
+# Compute number of repetitions per nonzero index and re-scale ERI. 
+rep = jax.jit(vmap_num_repetitions_fast, backend="cpu")(nonzero_indices)
 nonzero_distinct_ERI = nonzero_distinct_ERI / rep
 
-us = jax.jit(sparse_symmetric_einsum, backend=backend)(nonzero_distinct_ERI, nonzero_indices, dm)
-us = np.array(us)
+diff_JK = jax.jit(jax.checkpoint(sparse_symmetric_einsum), backend=backend)(nonzero_distinct_ERI, nonzero_indices, dm)
+diff_JK = np.array(diff_JK)
 
-us = us.reshape(N, N)
-print(us.reshape(-1)[::51])
+diff_JK = diff_JK.reshape(N, N)
+print(diff_JK.reshape(-1)[::51])
 print(truth.reshape(-1)[::51])
-print(np.max(np.abs(us.reshape(-1) - truth.reshape(-1))))
-assert np.allclose(us, truth, atol=1e-6)
+print(np.max(np.abs(diff_JK.reshape(-1) - truth.reshape(-1))))
+assert np.allclose(diff_JK, truth, atol=1e-6)
 print("PASSED!")

--- a/nanoDFT/sparse_symmetric_ERI.py
+++ b/nanoDFT/sparse_symmetric_ERI.py
@@ -1,43 +1,18 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 import pyscf 
 import numpy as np 
 import jax 
 import jax.numpy as jnp 
+import os.path as osp
+from tessellate_ipu import create_ipu_tile_primitive, ipu_cycle_count, tile_map, tile_put_sharded, tile_put_replicated
+from functools import partial 
 jax.config.update('jax_platform_name', "cpu")
 jax.config.update('jax_enable_x64', False) 
-import argparse 
-parser = argparse.ArgumentParser(prog='', description='', epilog='')
-parser.add_argument('-backend', default="cpu"),
-parser.add_argument('-natm', default=3),
-args = parser.parse_args()
-backend = args.backend 
-
-natm = int(args.natm) 
-
-mol = pyscf.gto.Mole(atom="".join(f"C 0 {1.54*j} {1.54*i};" for i in range(natm) for j in range(natm))) 
-mol.build()
-dense_ERI = mol.intor("int2e_sph", aosym="s1")
-distinct_ERI = mol.intor("int2e_sph", aosym="s8")
-N = mol.nao_nr()
-dm = pyscf.scf.hf.init_guess_by_minao(mol)         
 HYB_B3LYP = 0.2
-scale = HYB_B3LYP/2
-J = np.einsum("ijkl,ji->kl", dense_ERI, dm)
-K = np.einsum("ijkl,jk->il", dense_ERI, dm)
-truth = J - K / 2 * HYB_B3LYP
-
-nonzero_indices      = np.nonzero(distinct_ERI)[0].astype(np.int32)
-nonzero_distinct_ERI = distinct_ERI[nonzero_indices].astype(np.float32)
-print("[%i]"%mol.nao_nr())
-print("dense: ", dense_ERI.shape, dense_ERI.nbytes/10**6)
-print("sparse: ", distinct_ERI.shape, distinct_ERI.nbytes/10**6)
-print("sparse+symmetric: ", nonzero_distinct_ERI.shape, nonzero_distinct_ERI.nbytes/10**6)
-
-# todo: check if squareroot causes problems (as seen before). can mitigate using following trick! 
-def sqrt(x): return jnp.exp(1/2*jnp.log(x))
 
 def max_val(N):
-    x_candidate = (-1 + jnp.sqrt(1 + 8*N)) // 2 # i think above trick leads to overflow! 
-    x_candidate = (x_candidate).astype(jnp.int32) # this cast works as floor 
+    x_candidate = (-1 + jnp.sqrt(1 + 8*N)) // 2 # TODO: Check when this overflows and fix problem (e.g. N=500 => N^4/8 =7.8G > 2**32 for np.uint32).
+    x_candidate = (x_candidate).astype(jnp.int32) 
     x = jnp.where(x_candidate * (x_candidate + 1) // 2 <= N, x_candidate, x_candidate - 1)
     return x
 max_vals  = jax.vmap(max_val)
@@ -45,6 +20,48 @@ def get_i_j(val):
     i = max_val(val)
     j = val - i*(i+1)//2
     return i, j
+
+def cpu_ijkl(value, symmetry, mask, f): 
+    ij = max_val(value*mask[0])
+    kl = value - ij*(ij+1)//2
+    i, j = get_i_j(ij)
+    k, l = get_i_j(kl)
+    v      = f(i,j,k,l,symmetry) 
+    return v
+cpu_ijkl = jax.vmap(cpu_ijkl, in_axes=(0, None, None, None))
+
+@partial(jax.jit, backend="ipu")
+def ipu_ijkl(nonzero_indices, symmetry, N, mask):
+    mask = mask.astype(jnp.int32)
+    vertex_filename  = osp.join(osp.dirname(__file__), "compute_indices.cpp")
+    compute_indices= create_ipu_tile_primitive(
+            "indices",
+            "indices",
+            inputs=["value", "symmetry", "input_N", "mask", "start", "stop"],
+            outputs={"out": 0},
+            gp_filename=vertex_filename,
+            perf_estimate=100,
+    )
+
+    size = np.prod(nonzero_indices.shape)
+    total_threads = (1472-1) * 6 
+    remainder = size % total_threads
+    if remainder != 0: 
+        nonzero_indices = jnp.pad(nonzero_indices, (0, total_threads-remainder))
+    nonzero_indices = nonzero_indices.reshape(total_threads, -1) 
+
+    tiles = tuple((np.arange(0,total_threads) % (1471) + 1).astype(np.int32).tolist())
+    nonzero_indices = tile_put_sharded(nonzero_indices, tiles)
+    symmetry = jnp.array(symmetry, dtype=jnp.int32).reshape(1,)
+    symmetry = tile_put_replicated(symmetry,   tiles) 
+    mask     = tile_put_replicated(mask,   tiles)
+    N        = tile_put_replicated(N,   tiles)
+    start    = tile_put_replicated(0,   tiles)
+    stop     = tile_put_replicated(nonzero_indices.shape[1],   tiles)
+
+    value = tile_map(compute_indices, nonzero_indices, symmetry, N, mask, start, stop)  
+
+    return value.array.reshape(-1)[:size]
 
 def num_repetitions_fast(value):
     ij = max_val(value)
@@ -63,143 +80,153 @@ def num_repetitions_fast(value):
     return repetitions
 vmap_num_repetitions_fast = jax.vmap(num_repetitions_fast, in_axes=(0))
 
-def inverse_index_J_dm(value, symmetry, mask, f): 
-    ij = max_val(value*mask[0])
-    kl = value - ij*(ij+1)//2
-    i, j = get_i_j(ij)
-    k, l = get_i_j(kl)
+def sparse_symmetric_einsum(nonzero_distinct_ERI, nonzero_indices, dm, mask, backend):
+    dm = dm.reshape(-1)
+    diff_JK = jnp.zeros(dm.shape)
+    N = int(np.sqrt(dm.shape[0]))
 
-    v      = f(i,j,k,l,symmetry) 
-    return v
-def inverse_index_J_ss(value, symmetry, mask): 
-    ij = max_val(value*mask[0])
-    kl = value - ij*(ij+1)//2
-    i, j = get_i_j(ij)
-    k, l = get_i_j(kl)
-    matrix = [k*N+ l, k*N+ l, l*N+ k, l*N+ k ,  i*N+ j, i*N+ j, j*N+ i, j*N+ i ]
-    v      = matrix[symmetry] 
-    return  v
-get_ijkl = jax.vmap(inverse_index_J_dm, in_axes=(0, None, None, None))
-vmap_inverse_index_J_ss = jax.vmap(inverse_index_J_ss, in_axes=(0, None, None))
+    mask      = (mask-1)*jnp.sum(diff_JK)*jnp.sum(dm) + mask  # TODO: check if we can remove. 
+    
+    if backend == "cpu":
+        indices_func = lambda i,j,k,l,symmetry: jnp.array([i*N+j, j*N+i, i*N+j, j*N+i, k*N+l, l*N+k, k*N+l, l*N+k,
+                                                        k*N+l, k*N+l, l*N+k, l*N+k, i*N+j, i*N+j, j*N+i, j*N+i,
+                                                        k*N+j, k*N+i, l*N+j, l*N+i, i*N+l, i*N+k, j*N+l, j*N+k,
+                                                        i*N+l, j*N+l, i*N+k, j*N+k, k*N+j, l*N+j, k*N+i, l*N+i])[symmetry]
 
-value =jnp.ones(1, dtype=jnp.int32)*10
-mask = jnp.ones(1, dtype=jnp.int32)
-symmetry = 2
+    def iteration(symmetry, vals): 
+        diff_JK, mask= vals 
+        is_K_matrix = (symmetry >= 8)
 
-import os.path as osp
-from tessellate_ipu import create_ipu_tile_primitive, ipu_cycle_count, tile_map, tile_put_sharded, tile_put_replicated
-from functools import partial 
+        def sequentialized_iter(i, vals):
+            # Generalized J/K computation: does J when symmetry is in range(0,8) and K when symmetry is in range(8,16)
+            # Trade-off: Using one function leads to smaller always-live memory.
+            diff_JK, mask = vals 
 
+            indices = nonzero_indices[i]
+            eris    = nonzero_distinct_ERI[i]
 
-@partial(jax.jit, backend="ipu")
-def _vmap_inverse_index_J_dm(value, symmetry, N, mask):
-    vertex_filename  = osp.join(osp.dirname(__file__), "compute_indices.cpp")
-    compute_indices= create_ipu_tile_primitive(
-            "indices",
-            "indices",
-            inputs=["value", "symmetry", "input_N", "mask", "start", "stop"],
-            outputs={"value": 0},
-            gp_filename=vertex_filename,
-            perf_estimate=100,
-    )
+            if backend == "cpu": dm_indices = cpu_ijkl(indices, symmetry+is_K_matrix*8, mask, indices_func)  
+            else:                dm_indices = ipu_ijkl(indices, symmetry+is_K_matrix*8, N, mask)  
+            dm_values  = jnp.take(dm, dm_indices, axis=0) # causes peak 1 
+            print(eris.shape, dm_values.shape, indices.shape)
+            dm_values = dm_values.at[:].mul( eris ) #* mask  # this is prod, but re-use variable for inplace update. 
+            mask       = (mask-1)*jnp.sum(dm_values) + mask 
+            if backend == "cpu": ss_indices = cpu_ijkl(indices, symmetry+8+is_K_matrix*8, mask, indices_func) 
+            else:                ss_indices = ipu_ijkl(indices, symmetry+8+is_K_matrix*8, N, mask) 
+            diff_JK    = diff_JK + jax.ops.segment_sum(dm_values, ss_indices, N**2) * (-HYB_B3LYP/2)**is_K_matrix # causes peak 2 
+            mask       = (mask-1)*jnp.sum(diff_JK) + mask 
+            return [diff_JK, mask]
 
-    if value.shape[0] <= (1472-1)*6: 
-        tiles = tuple((np.arange(0,value.shape[0]) % (value.shape[0]//6) + 1).astype(np.int32).tolist())
-        symmetry = jnp.array(symmetry, dtype=jnp.int32).reshape(1,)
-        value = tile_put_sharded(value, tiles)
-        symmetry = tile_put_replicated(symmetry,   tiles)
-        N  = tile_put_replicated(N,   tiles)
-        mask  = tile_put_replicated(mask,   tiles)
-        index = tile_map(compute_indices, value, symmetry, N, mask )
+        batches = nonzero_indices.shape[0] # before pmap, tensor had shape (nipus, batches, -1) so [0]=batches after pmap
+        diff_JK, mask = jax.lax.fori_loop(0, batches, sequentialized_iter, [diff_JK, mask]) 
+        return [diff_JK, mask]
 
-    else: 
-        # loop around them.
-        size = value.shape[0]
-        print(value.shape)
+    diff_JK, mask = jax.lax.fori_loop(0, 16, iteration, [diff_JK, mask]) 
+    return jax.lax.psum(diff_JK, axis_name="p")
+
+if __name__ == "__main__":
+    import time 
+    import argparse 
+    parser = argparse.ArgumentParser(prog='', description='', epilog='')
+    parser.add_argument('-backend', default="cpu"),
+    parser.add_argument('-natm', default=3),
+    parser.add_argument('-test', action="store_true")
+    parser.add_argument('-prof', action="store_true")
+    parser.add_argument('-batches', default=5)
+    parser.add_argument('-nipu', default=16)
+    parser.add_argument('-skip', action="store_true") 
+    args = parser.parse_args()
+    backend = args.backend 
+
+    natm = int(args.natm) 
+    nipu = int(args.nipu)
+    if backend == "cpu": nipu = 1
+
+    start = time.time()
+
+    mask = jnp.ones(1, dtype=jnp.int32)
+    mol = pyscf.gto.Mole(atom="".join(f"C 0 {1.54*j} {1.54*i};" for i in range(natm) for j in range(natm))) 
+    mol.build()
+    N = mol.nao_nr()
+    print("[%i]"%mol.nao_nr())
+    if not args.skip: 
+        print("dense_ERI", time.time()-start)
+        dense_ERI = mol.intor("int2e_sph", aosym="s1")
+    print("distinct_ERI", time.time()-start)
+    distinct_ERI = mol.intor("int2e_sph", aosym="s8")
+    print("Minao init", time.time()-start)
+    dm = pyscf.scf.hf.init_guess_by_minao(mol)         
+    HYB_B3LYP = 0.2
+    scale = HYB_B3LYP/2
+    if not args.skip: 
+        print("einsum J", time.time()-start)
+        J = np.einsum("ijkl,ji->kl", dense_ERI, dm)
+        print("einsum K", time.time()-start)
+        K = np.einsum("ijkl,jk->il", dense_ERI, dm)
+        print("J-K/2", time.time()-start)
+        truth = J - K / 2 * HYB_B3LYP
+
+    print("\n----------")
+    print("nonzero_indices ", time.time()-start)
+    nonzero_indices      = np.nonzero(distinct_ERI)[0].astype(np.int32)
+    print("grap ERI values", time.time()-start)
+    nonzero_distinct_ERI = distinct_ERI[nonzero_indices].astype(np.float32)
+    if not args.skip: 
+        print("dense: ", dense_ERI.shape, dense_ERI.nbytes/10**6)
+    print("sparse: ", distinct_ERI.shape, distinct_ERI.nbytes/10**6)
+    print("sparse+symmetric: ", nonzero_distinct_ERI.shape, nonzero_distinct_ERI.nbytes/10**6)
+    print("per ipu", nonzero_distinct_ERI.nbytes/10**6/16*2) # obs: most time might be spent compiling loading ERI from H->device! 
+    print("----------\n")
+
+    # write code that profiles get_indices/take/segment_sum independently. 
+    if args.prof: 
+        symmetry = 7 
+        dm_indices = get_ijkl(nonzero_indices, symmetry, mask, dm_indices_func_J)  
+
+        size = nonzero_indices.shape[0]
         total_threads = (1472-1) * 6 
         remainder = size % total_threads
         if remainder != 0: 
-            value = jnp.pad(value, (0, total_threads-remainder))
+            nonzero_indices = np.pad(nonzero_indices, (0, total_threads-remainder))
+        nonzero_indices = nonzero_indices.reshape(total_threads, -1) 
 
-        tiles = tuple((np.arange(0,total_threads) % (1471) + 1).astype(np.int32).tolist())
-        value = value.reshape(total_threads, -1) 
-        value = tile_put_sharded(value, tiles)
-        symmetry = jnp.array(symmetry, dtype=jnp.int32).reshape(1,)
-        symmetry = tile_put_replicated(symmetry,   tiles)
-        mask     = tile_put_replicated(mask,   tiles)
-        N        = tile_put_replicated(N,   tiles)
-        start    = tile_put_replicated(0,   tiles)
-        stop     = tile_put_replicated(value.shape[1],   tiles)
+        _dm_indices = np.asarray(_get_ijkl(nonzero_indices, symmetry, N, mask))[:size]
+        assert np.allclose(dm_indices, _dm_indices)
+        exit()
 
-        step_size = 1 
-        print(size//total_threads+1, step_size)
-        value = tile_map(compute_indices, value, symmetry, N, mask, start, stop  ) 
+    # Compute number of repetitions per nonzero index and re-scale ERI. 
+    print("compute eri normalization ", time.time()-start)
+    rep = jax.jit(vmap_num_repetitions_fast, backend="cpu")(nonzero_indices)
+    print("perform normalization ", time.time()-start)
+    nonzero_distinct_ERI = nonzero_distinct_ERI / rep
+    mask = np.ones(1)
+    dm = dm.reshape(-1)
+    diff_JK = np.zeros(dm.shape)
 
-    return value.array.reshape(-1)[:size]
+    print("pad remainder ", time.time()-start)
+    print(nonzero_distinct_ERI.shape, nonzero_indices.shape)
+    batches = int(args.batches) # perhaps make 10 batches? 
+    remainder = nonzero_indices.shape[0] % (nipu*batches)
+    if remainder != 0:
+        nonzero_indices = np.pad(nonzero_indices, (0,nipu*batches-remainder))
+        nonzero_distinct_ERI = np.pad(nonzero_distinct_ERI, (0,nipu*batches-remainder))
 
-def inverse_index_K_dm(value, symmetry, mask): 
-    ij = max_val(value*mask[0])
-    kl = value - ij*(ij+1)//2
-    i, j = get_i_j(ij) 
-    k, l = get_i_j(kl)
-    # same as _J but "flip 0'th and 2'nd column"
-    matrix = [k*N+ j, k*N+ i, l*N+ j, l*N+ i, i*N+ l, i*N+ k, j*N+ l, j*N+ k ]
-    v      = matrix[symmetry] 
-    return v
-def inverse_index_K_ss(value, symmetry, mask): 
-    ij = max_val(value*mask[0])
-    kl = value - ij*(ij+1)//2
-    i, j = get_i_j(ij)
-    k, l = get_i_j(kl)
-    # same as _J but "flip 0'th and 2'nd column"
-    matrix = [i*N+ l, j*N+ l, i*N+ k, j*N+ k, k*N+ j, l*N+ j, k*N+ i, l*N+ i ]
-    v      = matrix[symmetry] 
-    return  v
-vmap_inverse_index_K_dm = jax.vmap(inverse_index_K_dm, in_axes=(0, None, None))
-vmap_inverse_index_K_ss = jax.vmap(inverse_index_K_ss, in_axes=(0, None, None))
+    print("reshape to 16 IPUs pmap", time.time()-start)
+    nonzero_indices = nonzero_indices.reshape(nipu, batches, -1)
+    nonzero_distinct_ERI = nonzero_distinct_ERI.reshape(nipu, batches, -1)
+    print(nonzero_indices.shape)
+    print(nonzero_distinct_ERI.shape)
 
-def sparse_symmetric_einsum(nonzero_distinct_ERI, nonzero_indices, dm, mask, diff_JK):
-    mask      = (mask-1)*jnp.sum(diff_JK)*jnp.sum(dm) + mask 
+    print("call pmap", time.time()-start)
+    print("[%i]"%mol.nao_nr())
+    diff_JK = jax.pmap( sparse_symmetric_einsum, in_axes=(0,0,None,None,None, None), static_broadcasted_argnums=(5,), backend=backend, axis_name="p") (nonzero_distinct_ERI, nonzero_indices, dm, mask, diff_JK, args.backend) 
+    if args.skip: 
+        exit()
+    diff_JK = np.array(diff_JK[0])
 
-    dm_indices_func_J = lambda i,j,k,l,symmetry: jnp.array([i*N+ j, j*N+ i, i*N+ j, j*N+ i, k*N+ l, l*N+ k, k*N+ l, l*N+ k])[symmetry]
-    ss_indices_func_J = lambda i,j,k,l,symmetry: jnp.array([k*N+ l, k*N+ l, l*N+ k, l*N+ k, i*N+ j, i*N+ j, j*N+ i, j*N+ i])[symmetry]
-    dm_indices_func_K = lambda i,j,k,l,symmetry: jnp.array([k*N+ j, k*N+ i, l*N+ j, l*N+ i, i*N+ l, i*N+ k, j*N+ l, j*N+ k])[symmetry]
-    ss_indices_func_K = lambda i,j,k,l,symmetry: jnp.array([i*N+ l, j*N+ l, i*N+ k, j*N+ k, k*N+ j, l*N+ j, k*N+ i, l*N+ i])[symmetry]
-
-    for symmetry in range(8):   
-        # J matrix 
-        dm_indices = get_ijkl(nonzero_indices, symmetry, mask, dm_indices_func_J)  
-        dm_values  = jnp.take(dm*mask, dm_indices, axis=0)
-        prod       = dm_values * nonzero_distinct_ERI* mask 
-        mask       = (mask-1)*jnp.sum(prod) + mask 
-        ss_indices = get_ijkl(nonzero_indices, symmetry, mask, ss_indices_func_J) 
-        diff_JK    = diff_JK + jax.ops.segment_sum(prod, ss_indices, N**2) 
-        mask       = (mask-1)*jnp.sum(diff_JK) + mask 
-            
-        # K matrix 
-        dm_indices = get_ijkl(nonzero_indices, symmetry, mask, dm_indices_func_K) 
-        dm_values  = jnp.take(dm*mask, dm_indices, axis=0)
-        prod       = dm_values * nonzero_distinct_ERI*mask
-        mask       = (mask-1)*jnp.sum(prod) + mask 
-        ss_indices = get_ijkl(nonzero_indices, symmetry, mask, ss_indices_func_K) 
-        diff_JK    = diff_JK - jax.ops.segment_sum(prod, ss_indices, N**2) / 2 * HYB_B3LYP 
-        mask       = (mask-1)*jnp.sum(diff_JK) + mask 
-
-    return diff_JK
-
-# Compute number of repetitions per nonzero index and re-scale ERI. 
-rep = jax.jit(vmap_num_repetitions_fast, backend="cpu")(nonzero_indices)
-nonzero_distinct_ERI = nonzero_distinct_ERI / rep
-
-mask = np.ones(1)
-dm = dm.reshape(-1)
-diff_JK = np.zeros(dm.shape)
-diff_JK = jax.jit(sparse_symmetric_einsum, backend=backend)(nonzero_distinct_ERI, nonzero_indices, dm, mask, diff_JK)
-diff_JK = np.array(diff_JK)
-
-diff_JK = diff_JK.reshape(N, N)
-print(diff_JK.reshape(-1)[::51])
-print(truth.reshape(-1)[::51])
-print(np.max(np.abs(diff_JK.reshape(-1) - truth.reshape(-1))))
-assert np.allclose(diff_JK, truth, atol=1e-6)
-print("PASSED!")
+    diff_JK = diff_JK.reshape(N, N)
+    print(diff_JK.reshape(-1)[::51])
+    print(truth.reshape(-1)[::51])
+    print(np.max(np.abs(diff_JK.reshape(-1) - truth.reshape(-1))))
+    assert np.allclose(diff_JK, truth, atol=1e-6)
+    print("PASSED!")

--- a/nanoDFT/sparse_symmetric_ERI.py
+++ b/nanoDFT/sparse_symmetric_ERI.py
@@ -218,7 +218,7 @@ if __name__ == "__main__":
 
     print("call pmap", time.time()-start)
     print("[%i]"%mol.nao_nr())
-    diff_JK = jax.pmap( sparse_symmetric_einsum, in_axes=(0,0,None,None,None, None), static_broadcasted_argnums=(5,), backend=backend, axis_name="p") (nonzero_distinct_ERI, nonzero_indices, dm, mask, diff_JK, args.backend) 
+    diff_JK = jax.pmap( sparse_symmetric_einsum, in_axes=(0,0,None,None,None, None), static_broadcasted_argnums=(4,), backend=backend, axis_name="p") (nonzero_distinct_ERI, nonzero_indices, dm, mask, args.backend) 
     if args.skip: 
         exit()
     diff_JK = np.array(diff_JK[0])

--- a/nanoDFT/sparse_symmetric_ERI.py
+++ b/nanoDFT/sparse_symmetric_ERI.py
@@ -156,7 +156,6 @@ if __name__ == "__main__":
     distinct_ERI = mol.intor("int2e_sph", aosym="s8")
     print("Minao init", time.time()-start)
     dm = pyscf.scf.hf.init_guess_by_minao(mol)         
-    HYB_B3LYP = 0.2
     scale = HYB_B3LYP/2
     if not args.skip: 
         print("einsum J", time.time()-start)

--- a/nanoDFT/sparse_symmetric_ERI.py
+++ b/nanoDFT/sparse_symmetric_ERI.py
@@ -35,8 +35,8 @@ def ipu_ijkl(nonzero_indices, symmetry, N, mask):
     mask = mask.astype(jnp.int32)
     vertex_filename  = osp.join(osp.dirname(__file__), "compute_indices.cpp")
     compute_indices= create_ipu_tile_primitive(
-            "indices",
-            "indices",
+            "SymmetryIndices",
+            "SymmetryIndices",
             inputs=["value", "symmetry", "input_N", "mask", "start", "stop"],
             outputs={"out": 0},
             gp_filename=vertex_filename,


### PR DESCRIPTION
`N=500` sto3g 100 carbon atoms in 10x10 grid **(this directly computes `J-K/2*HYB_B3LYP` no full dft)**

![image](https://github.com/graphcore-research/pyscf-ipu/assets/8614529/e5a76a97-7889-4794-8b5b-4def9950e2b7)

<hr>
**Results below are for full DFT computation.**  `N=80` sto3g 16 carbon atoms in 4x4 grid. 

![image](https://github.com/graphcore-research/pyscf-ipu/assets/8614529/84a258f2-6363-44b2-9977-bf2cabbbae5d)


<hr>

`N=180` sto3g 36 carbon atoms in 6x6 grid

![image](https://github.com/graphcore-research/pyscf-ipu/assets/8614529/634bdc77-bd13-4ce3-a6b5-1d4b95257189)

![image](https://github.com/graphcore-research/pyscf-ipu/assets/8614529/aa93c304-a420-4b3d-894c-f2246cf85b4c)

<hr>

`N=360` sto3g 64 carbons atoms in 8x8 grid (goes OOM due to bad tilin

![image](https://github.com/graphcore-research/pyscf-ipu/assets/8614529/08492d1e-e769-4e33-99e7-5bc65543adc5)

![image](https://github.com/graphcore-research/pyscf-ipu/assets/8614529/804459ed-f9c7-446d-883d-982abe13df52)

