### PR TITLE
Refactor - remove ordering trick

### DIFF
--- a/nanoDFT/compute_indices.cpp
+++ b/nanoDFT/compute_indices.cpp
@@ -45,7 +45,6 @@ public:
   InOut<Vector<int>>  value;
   Input<Vector<int>>  symmetry;
   Input<Vector<int>>  input_N;
-  Input<Vector<int>>  mask;
 
   Input<Vector<int>> start;
   Input<Vector<int>> stop; 


### PR DESCRIPTION
This PR simplifies the code by removing the mask-based trick which forced op order. This is now done correctly probably due to using a custom codelet.