### PR TITLE
Adding contribution guide and enable copyright checks as a pre-commit hook

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+
+copyright-check = True
+copyright-author = Graphcore Ltd

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,14 @@
+name: Pre-Commit Checks
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
+    hooks:
+      - id: flake8
+        args: [--select=C]
+        additional_dependencies: [flake8-copyright]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,38 +13,34 @@ activate the conda environment in a variety of scenarios:
 * running quick experiments in an interactive Jupyter window
 * using VS code for Jupyter notebook development.
 
-The following assumes that you have already setup an install of conda and that
+The following assumes that you have already set up an install of conda and that
 the conda command is available on your system path.  Refer to your preferred conda
 installer:
 * [miniforge installation](https://github.com/conda-forge/miniforge#install)
 * [conda installation documentation](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html).
 
-1. Create a new conda environment with the same python version as you OS.
+1. Create a new conda environment with the same python version as your OS.
    For example, on ubuntu 20 use `python=3.8.10`
    ```bash
    conda create -n pyscf-ipu python=3.8.10
    ```
 
 2. Confirm that you have the Poplar SDK installed on your machine and store the location
-   in an environment variable.  The following will test that the SDK is found and
+   in a temporary shell variable.  The following will test that the SDK is found and
    configured correctly:
    ```bash
-   export POPLAR_SDK=/path/to/sdk
-   source $POPLAR_SDK/enable
+   TMP_POPLAR_SDK=/path/to/sdk
+   source $TMP_POPLAR_SDK/enable
    gc-monitor
-   ```
 
-3. Activate the environment and store a persistent environment variable for the
-   location of the downloaded Poplar SDK. This assumes that
-   you have already downloaded the Poplar SDK.  The following example uses an
-   environment variable `$POPLAR_SDK` to store the root folder for the SDK.
+3. Activate the environment and make POPLAR_SDK a persistent environment variable.
    ```bash
    conda activate pyscf-ipu
-   conda env config vars set POPLAR_SDK=$POPLAR_SDK
+   conda env config vars set POPLAR_SDK=$TMP_POPLAR_SDK
    ```
 
 4. You have to reactivate the conda environment to use the `$POPLAR_SDK`
-   variable the environment.
+   variable in the environment.
    ```bash
    conda deactivate
    conda activate pyscf-ipu
@@ -57,13 +53,12 @@ installer:
    echo "source $POPLAR_SDK/enable" > $CONDA_PREFIX/etc/conda/activate.d/enable.sh
    ```
 
-6. Check that everything is working by once again reactivating the pyscf-ipu
-   environment and calling `gc-monitor`:
+6. Check that everything is working by once reactivating the pyscf-ipu
+   environment _in a new shell_ and calling `gc-monitor`:
    ```bash
    conda deactivate
    conda activate pyscf-ipu
    gc-monitor
-   ```
 
 7. Install all required packages for developing JAX DFT:
    ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,13 +21,22 @@ installer:
    conda create -n pyscf-ipu python=3.8.10
    ```
 
-2. Activate the environment and store a persistent environment variable for the
+2. Confirm that you have the Poplar SDK installed on your machine and store the location
+   in an environment variable.  The following will test that the SDK is found and
+   configured correctly:
+   ```bash
+   export POPLAR_SDK=/path/to/sdk
+   source $POPLAR_SDK/enable
+   gc-monitor
+   ```
+
+3.  Activate the environment and store a persistent environment variable for the
    location of the downloaded Poplar SDK. This assumes that
    you have already downloaded the Poplar SDK.  The following example uses an
    environment variable `$POPLAR_SDK` to store the root folder for the SDK.
    ```bash
    conda activate pyscf-ipu
-   conda env config vars set POPLAR_SDK=/path/to/poplar/sdk
+   conda env config vars set POPLAR_SDK=$POPLAR_SDK
    ```
 
 3. You have to reactivate the conda environment to use the `$POPLAR_SDK`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ installer:
 * [miniforge installation](https://github.com/conda-forge/miniforge#install)
 * [conda installation documentation](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html).
 
-1. Create a new conda environment with the same python version as your OS.
+1. Create a new conda environment with the same python version as required by the Poplar SDK.
    For example, on ubuntu 20 use `python=3.8.10`
    ```bash
    conda create -n pyscf-ipu python=3.8.10

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,81 @@
+# Contributing to pyscf-ipu
+
+
+## Setting up a development environment
+We recommend using the conda package manager as this can automatically enable
+the Graphcore Poplar SDK.  This is particularly useful in VS Code which can automatically
+activate the conda environment in a variety of scenarios:
+* visual debugging
+* running quick experiments in an interactive Jupyter window
+* using VS code for Jupyter notebook development.
+
+The following assumes that you have already setup an install of conda and that
+the conda command is available on your system path.  Refer to your preferred conda
+installer:
+* [miniforge installation](https://github.com/conda-forge/miniforge#install)
+* [conda installation documentation](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html).
+
+1. Create a new conda environment with the same python version as you OS.
+   For example, on ubuntu 20 use `python=3.8.10`
+   ```bash
+   conda create -n pyscf-ipu python=3.8.10
+   ```
+
+2. Activate the environment and store a persistent environment variable for the
+   location of the downloaded Poplar SDK. This assumes that
+   you have already downloaded the Poplar SDK.  The following example uses an
+   environment variable `$POPLAR_SDK` to store the root folder for the SDK.
+   ```bash
+   conda activate pyscf-ipu
+   conda env config vars set POPLAR_SDK=/path/to/poplar/sdk
+   ```
+
+3. You have to reactivate the conda environment to use the `$POPLAR_SDK`
+   variable the environment.
+   ```bash
+   conda deactivate
+   conda activate pyscf-ipu
+   ```
+
+4. Setup the conda environment to automatically enable the Poplar SDK whenever
+   the environment is activated.
+   ```bash
+   mkdir -p $CONDA_PREFIX/etc/conda/activate.d
+   echo "source $POPLAR_SDK/enable" > $CONDA_PREFIX/etc/conda/activate.d/enable.sh
+   ```
+
+5. Check that everything is working by once again reactivating the pyscf-ipu
+   environment and calling `gc-monitor`:
+   ```bash
+   conda deactivate
+   conda activate pyscf-ipu
+   gc-monitor
+   ```
+
+5. Install all required packages for developing JAX DFT:
+   ```bash
+   pip install -e ".[ipu,test]"
+   ```
+
+6. Install the pre-commit hooks
+   ```bash
+   pre-commit install
+   ```
+
+7. Create a feature branch, make changes, and when you commit them the
+   pre-commit hooks will run.
+   ```bash
+   git checkout -b feature
+   ...
+   git push --set-upstream origin feature
+   ```
+   The last command will prints a link that you can follow to open a PR.
+
+
+## Testing
+Run all the tests using `pytest`
+```bash
+pytest
+```
+
+## Profiling

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,9 @@
 # Contributing to pyscf-ipu
 
+This project is still evolving but at the moment is focused around a high-performance and easily hackable implementation of Gaussian basis set DFT.
+We hope this is useful for the generation of large-scale datasets needed
+for training machine-learning models. We are interested in hearing any and
+all feedback so feel free to raise any questions, bugs encountered, or enhancement requests as [Issues](https://github.com/graphcore-research/pyscf-ipu/issues).
 
 ## Setting up a development environment
 We recommend using the conda package manager as this can automatically enable
@@ -30,7 +34,7 @@ installer:
    gc-monitor
    ```
 
-3.  Activate the environment and store a persistent environment variable for the
+3. Activate the environment and store a persistent environment variable for the
    location of the downloaded Poplar SDK. This assumes that
    you have already downloaded the Poplar SDK.  The following example uses an
    environment variable `$POPLAR_SDK` to store the root folder for the SDK.
@@ -39,21 +43,21 @@ installer:
    conda env config vars set POPLAR_SDK=$POPLAR_SDK
    ```
 
-3. You have to reactivate the conda environment to use the `$POPLAR_SDK`
+4. You have to reactivate the conda environment to use the `$POPLAR_SDK`
    variable the environment.
    ```bash
    conda deactivate
    conda activate pyscf-ipu
    ```
 
-4. Setup the conda environment to automatically enable the Poplar SDK whenever
+5. Setup the conda environment to automatically enable the Poplar SDK whenever
    the environment is activated.
    ```bash
    mkdir -p $CONDA_PREFIX/etc/conda/activate.d
    echo "source $POPLAR_SDK/enable" > $CONDA_PREFIX/etc/conda/activate.d/enable.sh
    ```
 
-5. Check that everything is working by once again reactivating the pyscf-ipu
+6. Check that everything is working by once again reactivating the pyscf-ipu
    environment and calling `gc-monitor`:
    ```bash
    conda deactivate
@@ -61,17 +65,17 @@ installer:
    gc-monitor
    ```
 
-5. Install all required packages for developing JAX DFT:
+7. Install all required packages for developing JAX DFT:
    ```bash
    pip install -e ".[ipu,test]"
    ```
 
-6. Install the pre-commit hooks
+8. Install the pre-commit hooks
    ```bash
    pre-commit install
    ```
 
-7. Create a feature branch, make changes, and when you commit them the
+9. Create a feature branch, make changes, and when you commit them the
    pre-commit hooks will run.
    ```bash
    git checkout -b feature
@@ -86,5 +90,7 @@ Run all the tests using `pytest`
 ```bash
 pytest
 ```
-
-## Profiling
+We also use the nbmake package to check our notebooks work in the `IpuModel` environment.  These checks can also be run on IPU hardware equiped machines e.g.:
+```bash
+pytest --nbmake --nbmake-timeout=3000 notebooks/nanoDFT-demo.ipynb
+```

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![notebook-tests](https://github.com/graphcore-research/pyscf-ipu/actions/workflows/notebooks.yaml/badge.svg)](https://github.com/graphcore-research/pyscf-ipu/actions/workflows/notebooks.yaml)
 [![nanoDFT CLI](https://github.com/graphcore-research/pyscf-ipu/actions/workflows/cli.yaml/badge.svg)](https://github.com/graphcore-research/pyscf-ipu/actions/workflows/cli.yaml)
 [![unit tests](https://github.com/graphcore-research/pyscf-ipu/actions/workflows/unittest.yaml/badge.svg)](https://github.com/graphcore-research/pyscf-ipu/actions/workflows/unittest.yaml)
+[![pre-commit checks](https://github.com/graphcore-research/pyscf-ipu/actions/workflows/pre-commit.yaml/badge.svg)](https://github.com/graphcore-research/pyscf-ipu/actions/workflows/pre-commit.yaml)
 
 [**Installation guide**](#installation)
 | [**Example DFT Computations**](#example-dft-computations)

--- a/notebooks/plot_utils.py
+++ b/notebooks/plot_utils.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 import numpy as np
 import matplotlib as mpl
 import matplotlib.pyplot as plt

--- a/pyscf_ipu/electron_repulsion/__init__.py
+++ b/pyscf_ipu/electron_repulsion/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.

--- a/pyscf_ipu/exchange_correlation/__init__.py
+++ b/pyscf_ipu/exchange_correlation/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.

--- a/pyscf_ipu/exchange_correlation/b88.py
+++ b/pyscf_ipu/exchange_correlation/b88.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 # The functional definition in this file was ported to Python
 # from XCFun, which is Copyright Ulf Ekström and contributors 2009-2020
 # and provided under the Mozilla Public License (v2.0)

--- a/pyscf_ipu/exchange_correlation/lyp.py
+++ b/pyscf_ipu/exchange_correlation/lyp.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 # The functional definition in this file was ported to Python
 # from XCFun, which is Copyright Ulf Ekström and contributors 2009-2020
 # and provided under the Mozilla Public License (v2.0)

--- a/pyscf_ipu/exchange_correlation/vwn.py
+++ b/pyscf_ipu/exchange_correlation/vwn.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 # The functional definition in this file was ported to Python
 # from XCFun, which is Copyright Ulf Ekström and contributors 2009-2020
 # and provided under the Mozilla Public License (v2.0)

--- a/pyscf_ipu/nanoDFT/__init__.py
+++ b/pyscf_ipu/nanoDFT/__init__.py
@@ -1,1 +1,2 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 from .nanoDFT import *

--- a/pyscf_ipu/nanoDFT/sparse_ERI.py
+++ b/pyscf_ipu/nanoDFT/sparse_ERI.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 import numpy as np 
 import jax.numpy as jnp
 import os 

--- a/pyscf_ipu/nanoDFT/symmetric_ERI.py
+++ b/pyscf_ipu/nanoDFT/symmetric_ERI.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 import numpy as np 
 import jax.numpy as jnp
 import os 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,3 +6,6 @@
 #    requirements_ipu.txt for ipu backend configuration
 pytest
 nbmake
+pre-commit
+flake8
+flake8-copyright


### PR DESCRIPTION
This patch adds a contribution guide covering setting up a development environment for IPU development.  This guide was initially developed for other projects (see [hydronet-gnn](https://github.com/graphcore-research/hydronet-gnn/blob/main/CONTRIBUTING.md)).  While reviewing the steps it occurred to me that we don't have a copyright check (required for OSS) so I've implemented a basic pre-commit hook that applies the [flake8-copyright](https://pypi.org/project/flake8-copyright/) check.

Adds the following test-only dependencies:

* [pre-commit](https://github.com/pre-commit/pre-commit)
* [flake8](https://github.com/pycqa/flake8)
* [flake8-copyright](https://github.com/savoirfairelinux/flake8-copyright)