### PR TITLE
Configure pytest to show stdout and use verbose outputs

### DIFF
--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -33,4 +33,4 @@ jobs:
           JAX_IPU_MODEL_NUM_TILES: 46
           JAX_PLATFORMS: cpu,ipu
         run: |
-          pytest -s .
+          pytest .

--- a/.pytest.ini
+++ b/.pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -s -v


### PR DESCRIPTION
This adds the `.pytest.ini` file which configures the default cmd line arguments used when invoking `pytest`