### PR TITLE
Add function decorator for comparing fp64 to fp32

### DIFF
--- a/pyscf_ipu/experimental/integrals.py
+++ b/pyscf_ipu/experimental/integrals.py
@@ -24,11 +24,20 @@ Special functions used in integral evaluation
 """
 
 
-def factorial(n: IntN, nmax: int = LMAX) -> IntN:
+def factorial_fori(n: IntN, nmax: int = LMAX) -> IntN:
     def body_fun(i, val):
         return val * jnp.where(i <= n, i, 1)
 
     return lax.fori_loop(1, nmax + 1, body_fun, jnp.ones_like(n))
+
+
+def factorial_gamma(n: IntN) -> IntN:
+    from jax.scipy.special import gammaln
+
+    return jnp.exp(gammaln(n + 1))
+
+
+factorial = factorial_fori
 
 
 def factorial2(n: IntN, nmax: int = 2 * LMAX) -> IntN:

--- a/pyscf_ipu/experimental/integrals.py
+++ b/pyscf_ipu/experimental/integrals.py
@@ -32,9 +32,12 @@ def factorial_fori(n: IntN, nmax: int = LMAX) -> IntN:
 
 
 def factorial_gamma(n: IntN) -> IntN:
-    from jax.scipy.special import gammaln
+    """Appoximate factorial by evaluating the gamma function in log-space.
 
-    return jnp.exp(gammaln(n + 1))
+    This approximation is exact for small integers (n < 10).
+    """
+    approx = jnp.exp(gammaln(n + 1))
+    return jnp.rint(approx)
 
 
 factorial = factorial_fori

--- a/pyscf_ipu/experimental/numerics.py
+++ b/pyscf_ipu/experimental/numerics.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+from functools import wraps
+
+import jax.numpy as jnp
+import numpy as np
+
+
+def apply_fpcast(v, dtype):
+    if isinstance(v, jnp.ndarray) and v.dtype.kind == "f":
+        return v.astype(dtype)
+
+    return v
+
+
+def fpcast(func, dtype=jnp.float32):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        inputs = [apply_fpcast(v, dtype) for v in args]
+        outputs = func(*inputs, **kwargs)
+        return outputs
+
+    return wrapper
+
+
+def compare_fp32_to_fp64(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        outputs_fp32 = fpcast(func, dtype=jnp.float32)(*args, **kwargs)
+        outputs_fp64 = fpcast(func, dtype=jnp.float64)(*args, **kwargs)
+        print_compare(outputs_fp32, outputs_fp64)
+        return outputs_fp32
+
+    return wrapper
+
+
+def print_compare(fp32, fp64):
+    fp32 = [fp32] if isinstance(fp32, jnp.ndarray) else fp32
+    fp64 = [fp64] if isinstance(fp64, jnp.ndarray) else fp64
+
+    for low, high in zip(fp32, fp64):
+        low = np.asarray(low).astype(np.float64)
+        high = np.asarray(high)
+        print(f" max |fp64 - fp32| = {np.abs(high - low).max()}")

--- a/pyscf_ipu/experimental/numerics.py
+++ b/pyscf_ipu/experimental/numerics.py
@@ -4,6 +4,7 @@ from typing import Callable
 
 import jax.numpy as jnp
 import numpy as np
+from jax.experimental import enable_x64
 from jaxtyping import Array
 
 
@@ -27,10 +28,11 @@ def fpcast(func: Callable, dtype=jnp.float32):
 def compare_fp32_to_fp64(func: Callable):
     @wraps(func)
     def wrapper(*args, **kwargs):
-        outputs_fp32 = fpcast(func, dtype=jnp.float32)(*args, **kwargs)
-        outputs_fp64 = fpcast(func, dtype=jnp.float64)(*args, **kwargs)
-        print_compare(func.__name__, outputs_fp32, outputs_fp64)
-        return outputs_fp32
+        with enable_x64():
+            outputs_fp32 = fpcast(func, dtype=jnp.float32)(*args, **kwargs)
+            outputs_fp64 = fpcast(func, dtype=jnp.float64)(*args, **kwargs)
+            print_compare(func.__name__, outputs_fp32, outputs_fp64)
+            return outputs_fp32
 
     return wrapper
 

--- a/pyscf_ipu/experimental/numerics.py
+++ b/pyscf_ipu/experimental/numerics.py
@@ -1,18 +1,20 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 from functools import wraps
+from typing import Callable
 
 import jax.numpy as jnp
 import numpy as np
+from jaxtyping import Array
 
 
-def apply_fpcast(v, dtype):
-    if isinstance(v, jnp.ndarray) and v.dtype.kind == "f":
+def apply_fpcast(v: Array, dtype: np.dtype):
+    if isinstance(v, jnp.ndarray) and np.issubdtype(v, np.floating):
         return v.astype(dtype)
 
     return v
 
 
-def fpcast(func, dtype=jnp.float32):
+def fpcast(func: Callable, dtype=jnp.float32):
     @wraps(func)
     def wrapper(*args, **kwargs):
         inputs = [apply_fpcast(v, dtype) for v in args]
@@ -22,22 +24,22 @@ def fpcast(func, dtype=jnp.float32):
     return wrapper
 
 
-def compare_fp32_to_fp64(func):
+def compare_fp32_to_fp64(func: Callable):
     @wraps(func)
     def wrapper(*args, **kwargs):
         outputs_fp32 = fpcast(func, dtype=jnp.float32)(*args, **kwargs)
         outputs_fp64 = fpcast(func, dtype=jnp.float64)(*args, **kwargs)
-        print_compare(outputs_fp32, outputs_fp64)
+        print_compare(func.__name__, outputs_fp32, outputs_fp64)
         return outputs_fp32
 
     return wrapper
 
 
-def print_compare(fp32, fp64):
+def print_compare(name: str, fp32, fp64):
     fp32 = [fp32] if isinstance(fp32, jnp.ndarray) else fp32
     fp64 = [fp64] if isinstance(fp64, jnp.ndarray) else fp64
 
-    for low, high in zip(fp32, fp64):
+    for idx, (low, high) in enumerate(zip(fp32, fp64)):
         low = np.asarray(low).astype(np.float64)
         high = np.asarray(high)
-        print(f" max |fp64 - fp32| = {np.abs(high - low).max()}")
+        print(f"{name} output {idx} has max |fp64 - fp32| = {np.abs(high - low).max()}")

--- a/test/test_numerics.py
+++ b/test/test_numerics.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 import jax.numpy as jnp
+from jax.experimental import enable_x64
 from numpy.testing import assert_allclose
 
 from pyscf_ipu.experimental.integrals import factorial_fori, factorial_gamma
@@ -7,7 +8,9 @@ from pyscf_ipu.experimental.numerics import compare_fp32_to_fp64
 
 
 def test_factorial():
-    x = jnp.arange(8, dtype=jnp.float32)
-    y_fori = compare_fp32_to_fp64(factorial_fori)(x, 8)
-    y_gamma = compare_fp32_to_fp64(factorial_gamma)(x)
-    assert_allclose(y_fori, y_gamma, atol=1e-2)
+    with enable_x64():
+        n = 16
+        x = jnp.arange(n, dtype=jnp.float32)
+        y_fori = compare_fp32_to_fp64(factorial_fori)(x, n)
+        y_gamma = compare_fp32_to_fp64(factorial_gamma)(x)
+        assert_allclose(y_fori, y_gamma, 1e-2)

--- a/test/test_numerics.py
+++ b/test/test_numerics.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+import jax.numpy as jnp
+from numpy.testing import assert_allclose
+
+from pyscf_ipu.experimental.integrals import factorial_fori, factorial_gamma
+from pyscf_ipu.experimental.numerics import compare_fp32_to_fp64
+
+
+def test_factorial():
+    x = jnp.arange(8, dtype=jnp.float32)
+    y_fori = compare_fp32_to_fp64(factorial_fori)(x, 8)
+    y_gamma = compare_fp32_to_fp64(factorial_gamma)(x)
+    assert_allclose(y_fori, y_gamma, atol=1e-2)

--- a/test/test_numerics.py
+++ b/test/test_numerics.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 import jax.numpy as jnp
-from jax.experimental import enable_x64
 from numpy.testing import assert_allclose
 
 from pyscf_ipu.experimental.integrals import factorial_fori, factorial_gamma
@@ -8,9 +7,8 @@ from pyscf_ipu.experimental.numerics import compare_fp32_to_fp64
 
 
 def test_factorial():
-    with enable_x64():
-        n = 16
-        x = jnp.arange(n, dtype=jnp.float32)
-        y_fori = compare_fp32_to_fp64(factorial_fori)(x, n)
-        y_gamma = compare_fp32_to_fp64(factorial_gamma)(x)
-        assert_allclose(y_fori, y_gamma, 1e-2)
+    n = 16
+    x = jnp.arange(n, dtype=jnp.float32)
+    y_fori = compare_fp32_to_fp64(factorial_fori)(x, n)
+    y_gamma = compare_fp32_to_fp64(factorial_gamma)(x)
+    assert_allclose(y_fori, y_gamma, 1e-2)


### PR DESCRIPTION
This adds a function decorator that runs a function first with all inputs cast to fp32 and a second time with fp64.  Following this, `max |fp64 - fp32|` is printed for each of the function outputs.