### PR TITLE
Add performance tests

### DIFF
--- a/.pytest.ini
+++ b/.pytest.ini
@@ -1,2 +1,5 @@
 [pytest]
 addopts = -s -v --durations=10
+filterwarnings =
+    error
+    ignore::DeprecationWarning

--- a/test/test_benchmark_performance.py
+++ b/test/test_benchmark_performance.py
@@ -1,0 +1,77 @@
+from subprocess import call, Popen
+import os
+import pytest
+import numpy as np
+import jax
+
+from pyscf_ipu.nanoDFT.nanoDFT import nanoDFT_options, nanoDFT, build_mol
+
+from tessellate_ipu import tile_map, tile_put_replicated, tile_put_sharded
+from tessellate_ipu import ipu_cycle_count
+
+
+# def test_basic_demonstration():
+#     dummy = np.random.rand(2,3).astype(np.float32)
+#     dummier = np.random.rand(2,3).astype(np.float32)
+
+#     @jax.jit
+#     def jitted_inner_test(dummy, dummier):
+#         tiles = tuple(range(len(dummy)))
+#         dummy = tile_put_sharded(dummy, tiles)
+#         tiles = tuple(range(len(dummier)))
+#         dummier = tile_put_sharded(dummier, tiles)
+
+#         dummy, dummier, start = ipu_cycle_count(dummy, dummier)
+#         out = tile_map(jax.lax.add_p, dummy, dummier)
+#         out, end = ipu_cycle_count(out)
+
+#         return out, start, end
+
+#     _, start, end = jitted_inner_test(dummy, dummier)
+#     print("Start cycle count:", start, start.shape)
+#     print("End cycle count:", end, end.shape)
+#     print("Diff cycle count:", end.array - start.array)
+
+#     assert True
+
+@pytest.mark.parametrize("molecule", ["methane", "benzene"])
+def test_dense_eri(molecule):
+
+    opts, mol_str = nanoDFT_options(float32 = True, mol_str=molecule, backend="ipu")
+    mol = build_mol(mol_str, opts.basis)
+
+    _, _, ipu_cycles_stamps = nanoDFT(mol, opts, profile_performance=True)
+
+    start, end = ipu_cycles_stamps
+    start = np.asarray(start)
+    end = np.asarray(end)
+
+    diff = (end - start)[0][0][0]
+    print("----------------------------------------------------------------------------")
+    print("                                Diff cycle count:", diff)
+    print("                            Diff cycle count [M]:", diff/1e6)
+    print("Estimated time of execution on Bow-IPU [seconds]:", diff/(1.85*1e9))
+    print("----------------------------------------------------------------------------")
+
+    assert True
+
+@pytest.mark.parametrize("molecule", ["methane", "benzene", "c20"])
+def test_sparse_eri(molecule):
+
+    opts, mol_str = nanoDFT_options(float32 = True, mol_str=molecule, backend="ipu", dense_ERI=False, eri_threshold=1e-9)
+    mol = build_mol(mol_str, opts.basis)
+
+    _, _, ipu_cycles_stamps = nanoDFT(mol, opts, profile_performance=True)
+
+    start, end = ipu_cycles_stamps
+    start = np.asarray(start)
+    end = np.asarray(end)
+
+    diff = (end - start)[0][0][0]
+    print("----------------------------------------------------------------------------")
+    print("                                Diff cycle count:", diff)
+    print(                            "Diff cycle count [M]:", diff/1e6)
+    print("Estimated time of execution on Bow-IPU [seconds]:", diff/(1.85*1e9))
+    print("----------------------------------------------------------------------------")
+
+    assert True


### PR DESCRIPTION
This branch is adding performance tests for `nanoDFT`.

So far it is possible to just execute initial 5 tests with simple purest command `purest tests/test_benchmark_performance.py`.

The code injecting the `ipu_cycle_count` into the `_nanoDFT()` jitted method is WIP.

The branch is going to:
- [ ] add `nanoDFT()` performance evaluation with `ipu_cycle_count`
- [ ] use `pytest` for performance testing
- [ ] add new fullerene molecules such as C80 or C100
- [ ] consider using [https://github.com/benchmark-action/github-action-benchmark](GitHub Action benchmark) for performance tracking (either already within this branch or as a separate change)
- [ ] refactor the `ipu_cycle_count` code and move it to `utils`